### PR TITLE
Add deployment helper and update values.yaml for deployment configuration

### DIFF
--- a/charts/mycarrier-helm/templates/_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.tpl
@@ -178,3 +178,6 @@ Usage:
 {{- end -}}
 
 
+{{- define "helm.deployment" -}}
+{{ .Values.deployment | default "deployment" }}
+{{- end -}}

--- a/charts/mycarrier-helm/templates/offloads.yaml
+++ b/charts/mycarrier-helm/templates/offloads.yaml
@@ -1,6 +1,7 @@
 {{- if (eq .Values.environment.name "dev") }}
 {{- $fullName := include "helm.fullname" . }}
 {{- $namespace := include "helm.namespace" . }}
+{{- $deployment := include "helm.deployment" . }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
@@ -21,7 +22,7 @@ spec:
                     repoURL: https://github.com/MyCarrier-DevOps/GitOps-dev.git
                     revision: main
                 - list:
-                    elementsYaml: '{{`{{`}} .offloads | toJson {{`}}`}}'
+                    elementsYaml: '{{`{{`}} .offloads.{{ $deployment }} | toJson {{`}}`}}'
           - list:
               elements:
                 - Values:
@@ -41,6 +42,7 @@ spec:
                       domainOverride:
                         enabled: {{ .Values.environment.domainOverride.enabled }}
                         domain: {{ .Values.environment.domainOverride.domain }}
+                    deployment: {{ $deployment }}
                     applications: {{- with .Values.applications -}}
                     {{- . | toYaml | nindent 22 }}
                     {{- end }}
@@ -67,7 +69,7 @@ spec:
         helm:
           values: |2+
             {{`{{`}}- $Values := .Values {{`}}`}}
-            {{`{{`}}- .Values | toYaml | nindent 12 {{`}}`}}
+            {{`{{`}}- .Values | toYaml {{`}}`}}
       syncPolicy:
         automated:
           prune: true

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -77,6 +77,10 @@ tolerations: []
   #   value: "value"
   #   effect: "NoSchedule"
 
+# If your deployment specific values files are in "my-deployment" this field should be "my-deployment". 
+# Defaults to "deployment".
+deployment: deployment # <-- This should match the name of the subfolder containing the specific deployment. 
+
 ## @section Applications
 ## Configuration for application deployments
 

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -77,9 +77,8 @@ tolerations: []
   #   value: "value"
   #   effect: "NoSchedule"
 
-# If your deployment specific values files are in "my-deployment" this field should be "my-deployment". 
-# Defaults to "deployment".
-deployment: deployment # <-- This should match the name of the subfolder containing the specific deployment. 
+# This should match the name of the subfolder containing the specific deployment.
+deployment: deployment
 
 ## @section Applications
 ## Configuration for application deployments


### PR DESCRIPTION
This pull request introduces support for deployment-specific configuration in the Helm chart by allowing the deployment name to be parameterized. The main changes make it easier to manage and template values for different deployments by referencing a configurable `deployment` value throughout the chart.

**Deployment-specific configuration:**

* Added a new `deployment` value to `values.yaml`, allowing users to specify the deployment name, which defaults to `"deployment"`. This enables referencing deployment-specific values files and folders.
* Introduced a new Helm template helper `helm.deployment` in `_helpers.tpl` to return the deployment name from values.

**Template updates for deployment awareness:**

* Updated `offloads.yaml` to use the new `helm.deployment` helper and variable, so that `.offloads.<deployment>` is referenced instead of a static path. This allows dynamic selection of offload elements per deployment. [[1]](diffhunk://#diff-607b669bac91eb1e54b03ec61a6cb7a78a03518066bb2b35807a56382328a5daR4) [[2]](diffhunk://#diff-607b669bac91eb1e54b03ec61a6cb7a78a03518066bb2b35807a56382328a5daL24-R25)
* Injected the `deployment` variable into the generated ApplicationSet spec for downstream usage.

**Helm values templating fix:**

* Adjusted the Helm values templating in `offloads.yaml` to avoid unnecessary indentation, ensuring correct formatting of values.