### PR TITLE
Update ArgoCD sync-options to include Replace and PruneLast settings

### DIFF
--- a/charts/mycarrier-helm/templates/deployment.yaml
+++ b/charts/mycarrier-helm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $v2migration := .Values.global.v2migration | default false -}}
 {{- range $appName, $appValues := .Values.applications }}
 {{- $appContext := (merge (dict "appName" $appName "application" $appValues) $) }}
 {{- if (eq $appValues.deploymentType "deployment")  }}
@@ -14,7 +15,11 @@ metadata:
     {{ include "helm.labels.version" $appContext | indent 4 | trim }}
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    {{- if $v2migration }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false
+    {{- else }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    {{- end }}
 spec:
   {{ include "helm.specs.deployment" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/templates/deployment.yaml
+++ b/charts/mycarrier-helm/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{ include "helm.labels.version" $appContext | indent 4 | trim }}
   annotations:
     argocd.argoproj.io/sync-wave: "10"
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false
 spec:
   {{ include "helm.specs.deployment" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/templates/statefulset.yaml
+++ b/charts/mycarrier-helm/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $v2migration := .Values.global.v2migration | default false -}}
 {{- range $appName, $appValues := .Values.applications }}
 {{- $appContext := (merge (dict "appName" $appName "application" $appValues) $) }}
 {{- if (eq $appValues.deploymentType "statefulset")  }}
@@ -15,7 +16,11 @@ metadata:
     {{ include "helm.labels.version" $appContext | indent 4 | trim }}
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    {{- if $v2migration }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false
+    {{- else }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    {{- end }}
 spec:
   {{ include "helm.specs.statefulset" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/tests/v2migration_deployment_test.yaml
+++ b/charts/mycarrier-helm/tests/v2migration_deployment_test.yaml
@@ -1,0 +1,150 @@
+suite: V2 Migration Feature Tests - Deployments
+templates:
+  - deployment.yaml
+tests:
+  - it: should use default sync options when v2migration is false
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: false
+      environment:
+        name: "dev"
+      applications:
+        test-app:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "test-app"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true"
+      - notMatchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "Replace=true"
+      - notMatchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "PruneLast=false"
+
+  - it: should use v2migration sync options when v2migration is true
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: true
+      environment:
+        name: "dev"
+      applications:
+        test-app:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "test-app"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "SkipDryRunOnMissingResource=true"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "Replace=true"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "PruneLast=false"
+
+  - it: should default to false when v2migration is not set
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        # v2migration not explicitly set - should default to false
+      environment:
+        name: "dev"
+      applications:
+        test-app:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "test-app"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true"
+
+  - it: should work with multiple applications when v2migration is true
+    set:
+      global:
+        appStack: "multi"
+        language: "nodejs"
+        v2migration: true
+      environment:
+        name: "prod"
+      applications:
+        app1:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "app1"
+            tag: "1.0.0"
+        app2:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "app2"
+            tag: "2.0.0"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+      - isKind:
+          of: Deployment
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"
+        documentIndex: 1
+
+  - it: should preserve other annotations when v2migration is enabled
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: true
+      environment:
+        name: "dev"
+      applications:
+        test-app:
+          deploymentType: deployment
+          image:
+            registry: "registry.example.com"
+            repository: "test-app"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - exists:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"

--- a/charts/mycarrier-helm/tests/v2migration_statefulset_test.yaml
+++ b/charts/mycarrier-helm/tests/v2migration_statefulset_test.yaml
@@ -1,0 +1,111 @@
+suite: V2 Migration Feature Tests - StatefulSets
+templates:
+  - statefulset.yaml
+tests:
+  - it: should use default sync options for statefulset when v2migration is false
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: false
+      environment:
+        name: "dev"
+      applications:
+        test-statefulset:
+          deploymentType: statefulset
+          image:
+            registry: "registry.example.com"
+            repository: "test-statefulset"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true"
+      - notMatchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "Replace=true"
+      - notMatchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "PruneLast=false"
+
+  - it: should use v2migration sync options for statefulset when v2migration is true
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: true
+      environment:
+        name: "dev"
+      applications:
+        test-statefulset:
+          deploymentType: statefulset
+          image:
+            registry: "registry.example.com"
+            repository: "test-statefulset"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "SkipDryRunOnMissingResource=true"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "Replace=true"
+      - matchRegex:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          pattern: "PruneLast=false"
+
+  - it: should default to false for statefulset when v2migration is not set
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        # v2migration not explicitly set - should default to false
+      environment:
+        name: "dev"
+      applications:
+        test-statefulset:
+          deploymentType: statefulset
+          image:
+            registry: "registry.example.com"
+            repository: "test-statefulset"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true"
+
+  - it: should preserve other annotations for statefulset when v2migration is enabled
+    set:
+      global:
+        appStack: "test"
+        language: "nodejs"
+        v2migration: true
+      environment:
+        name: "dev"
+      applications:
+        test-statefulset:
+          deploymentType: statefulset
+          image:
+            registry: "registry.example.com"
+            repository: "test-statefulset"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - exists:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "SkipDryRunOnMissingResource=true,Replace=true,PruneLast=false"

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -21,6 +21,9 @@ global:
   # Use application-level language configuration to override
   language: "nodejs"
 
+  # Flag to indicate if we are migrating to v2 (enables certain ArgoCD sync options)
+  v2migration: false
+  
   env: {}
   dependencies:
     mongodb: false


### PR DESCRIPTION
This pull request updates the ArgoCD deployment sync options in the `charts/mycarrier-helm/templates/deployment.yaml` file. The main change is the addition of new sync options to control the deployment behavior more precisely.

ArgoCD deployment configuration:

* Updated the `argocd.argoproj.io/sync-options` annotation to include `Replace=true` and `PruneLast=false`, in addition to the existing `SkipDryRunOnMissingResource=true` option, to improve resource replacement and pruning behavior during syncs.