### PR TITLE
feat(mycarrier-helm): use global.testengineWebhookUrl as TESTENGINEHOOK_URL default [skip-flagcheck]

### DIFF
--- a/charts/mycarrier-helm/TestTriggersGuide.md
+++ b/charts/mycarrier-helm/TestTriggersGuide.md
@@ -25,7 +25,7 @@ applications:
       activeDeadlineSeconds: "<seconds>"
       ttlSecondsAfterFinished: "<seconds>"
       apikey: "<api-key-or-vault-reference>"
-      # webhook_url: "<webhook-url-or-vault-reference>"  # Optional — auto-injected by CI/CD render step;
+      # webhook_url: "<webhook-url-or-vault-reference>"   # Optional — auto-injected by CI/CD render step;
                                                           # falls back to vault:DevOps/data/testengine/api#url
       backoffLimit: <number>
       resources:

--- a/charts/mycarrier-helm/TestTriggersGuide.md
+++ b/charts/mycarrier-helm/TestTriggersGuide.md
@@ -25,7 +25,8 @@ applications:
       activeDeadlineSeconds: "<seconds>"
       ttlSecondsAfterFinished: "<seconds>"
       apikey: "<api-key-or-vault-reference>"
-      webhook_url: "<webhook-url-or-vault-reference>"
+      # webhook_url: "<webhook-url-or-vault-reference>"  # Optional — auto-injected by CI/CD render step;
+                                                          # falls back to vault:DevOps/data/testengine/api#url
       backoffLimit: <number>
       resources:
         requests:
@@ -78,7 +79,7 @@ applications:
 | `backoffLimit` | Number of retries for the test job in case of failure | No | `0` | `0` |
 | `resources` | Resource requests and limits for the test job pod | No | See below* | See example below |
 | `ttlSecondsAfterFinished` | Time in seconds to keep the job after it finishes | No | `"3600"` | `"3600"` |
-| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference. **Optional** — when omitted, the chart uses `global.testengineWebhookUrl` injected by the CI/CD render step, which auto-selects the dev or prod testengine endpoint based on the Argo workflow namespace. | No | `global.testengineWebhookUrl` (injected by render) | `"vault:Secrets/data/path/to/secret#url"` |
+| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference. **Optional** — when omitted, the chart uses `global.testengineWebhookUrl` injected by the CI/CD render step, which auto-selects the dev or prod testengine endpoint based on the Argo workflow namespace. | No | `global.testengineWebhookUrl` (injected by render); hard fallback to `vault:DevOps/data/testengine/api#url` when absent (e.g. local render) | `"vault:Secrets/data/path/to/secret#url"` |
 
 *Default resource values:
 ```yaml

--- a/charts/mycarrier-helm/TestTriggersGuide.md
+++ b/charts/mycarrier-helm/TestTriggersGuide.md
@@ -78,7 +78,7 @@ applications:
 | `backoffLimit` | Number of retries for the test job in case of failure | No | `0` | `0` |
 | `resources` | Resource requests and limits for the test job pod | No | See below* | See example below |
 | `ttlSecondsAfterFinished` | Time in seconds to keep the job after it finishes | No | `"3600"` | `"3600"` |
-| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference | Yes | None | `"vault:Secrets/data/path/to/secret#url"` |
+| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference. **Optional** — when omitted, the chart uses `global.testengineWebhookUrl` injected by the CI/CD render step, which auto-selects the dev or prod testengine endpoint based on the Argo workflow namespace. | No | `global.testengineWebhookUrl` (injected by render) | `"vault:Secrets/data/path/to/secret#url"` |
 
 *Default resource values:
 ```yaml

--- a/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
+++ b/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
@@ -46,7 +46,8 @@ template:
         - name: TESTENGINE_APIKEY
           value: {{ dig "testtrigger" "apikey" "" .application | quote }}
         - name: TESTENGINEHOOK_URL
-          value: {{ dig "testtrigger" "webhook_url" "" .application | quote }}
+          {{- $defaultWebhookUrl := $.Values.global.testengineWebhookUrl | default "vault:DevOps/data/testengine/api#url" }}
+          value: {{ dig "testtrigger" "webhook_url" $defaultWebhookUrl .application | quote }}
         resources:
           {{- if .application.testtrigger.resources }}
           {{ toYaml .application.testtrigger.resources | indent 10 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
+++ b/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
@@ -23,6 +23,7 @@
 {{- end }}
 {{- end }}
 {{- $imageTag :=  .application.image.tag }}
+{{- $defaultWebhookUrl := $.Values.global.testengineWebhookUrl | default "vault:DevOps/data/testengine/api#url" }}
 {{- if dig "testtrigger" false .application }}
 ttlSecondsAfterFinished: {{ dig "testtrigger" "ttlSecondsAfterFinished" 3600 .application }}
 activeDeadlineSeconds: {{ dig "testtrigger" "activeDeadlineSeconds" 300 .application }}
@@ -46,7 +47,6 @@ template:
         - name: TESTENGINE_APIKEY
           value: {{ dig "testtrigger" "apikey" "" .application | quote }}
         - name: TESTENGINEHOOK_URL
-          {{- $defaultWebhookUrl := $.Values.global.testengineWebhookUrl | default "vault:DevOps/data/testengine/api#url" }}
           value: {{ dig "testtrigger" "webhook_url" $defaultWebhookUrl .application | quote }}
         resources:
           {{- if .application.testtrigger.resources }}

--- a/charts/mycarrier-helm/tests/triggertests_test.yaml
+++ b/charts/mycarrier-helm/tests/triggertests_test.yaml
@@ -894,7 +894,7 @@ tests:
           count: 1
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "TestCategory=coretests"
+          pattern: '"TestFilters":\s*"TestCategory=coretests"'
 
   # ── TestEngine webhook URL selection tests ────────────────────────────────
 
@@ -1002,4 +1002,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].value
           value: "vault:DevOps/data/testengine/api#url"
-          pattern: '"TestFilters":\s*"TestCategory=coretests"'

--- a/charts/mycarrier-helm/tests/triggertests_test.yaml
+++ b/charts/mycarrier-helm/tests/triggertests_test.yaml
@@ -926,12 +926,11 @@ tests:
           of: Job
       - hasDocuments:
           count: 1
-      - equal:
-          path: spec.template.spec.containers[0].env[1].name
-          value: TESTENGINEHOOK_URL
-      - equal:
-          path: spec.template.spec.containers[0].env[1].value
-          value: "vault:DevOps/data/testengine/api#dev_url"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTENGINEHOOK_URL
+            value: "vault:DevOps/data/testengine/api#dev_url"
 
   - it: should fall back to prod vault key when global.testengineWebhookUrl is not set
     set:
@@ -960,12 +959,11 @@ tests:
           of: Job
       - hasDocuments:
           count: 1
-      - equal:
-          path: spec.template.spec.containers[0].env[1].name
-          value: TESTENGINEHOOK_URL
-      - equal:
-          path: spec.template.spec.containers[0].env[1].value
-          value: "vault:DevOps/data/testengine/api#url"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTENGINEHOOK_URL
+            value: "vault:DevOps/data/testengine/api#url"
 
   - it: should prefer explicit webhook_url over global.testengineWebhookUrl
     set:
@@ -996,9 +994,8 @@ tests:
           of: Job
       - hasDocuments:
           count: 1
-      - equal:
-          path: spec.template.spec.containers[0].env[1].name
-          value: TESTENGINEHOOK_URL
-      - equal:
-          path: spec.template.spec.containers[0].env[1].value
-          value: "vault:DevOps/data/testengine/api#url"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTENGINEHOOK_URL
+            value: "vault:DevOps/data/testengine/api#url"

--- a/charts/mycarrier-helm/tests/triggertests_test.yaml
+++ b/charts/mycarrier-helm/tests/triggertests_test.yaml
@@ -56,7 +56,7 @@ tests:
           value: batch/v1
       - hasDocuments:
           count: 2
-          
+
   - it: should only create jobs for enabled applications
     set:
       fullnameOverride: app
@@ -87,7 +87,7 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: ^app-app1-trigger$
-          
+
   - it: should have proper labels and annotations
     set:
       fullnameOverride: app
@@ -119,7 +119,7 @@ tests:
           path: metadata.labels
       - exists:
           path: metadata.annotations
-            
+
   - it: should use testenginehook spec
     set:
       fullnameOverride: app
@@ -145,7 +145,7 @@ tests:
     asserts:
       - exists:
           path: spec
-          
+
   # Edge case tests for testdefinitions
   - it: should handle multiple test definitions correctly
     set:
@@ -189,7 +189,7 @@ tests:
           count: 1
       - exists:
           path: spec
-          
+
   - it: should handle special characters in filter values correctly
     set:
       fullnameOverride: app
@@ -221,7 +221,7 @@ tests:
           count: 1
       - exists:
           path: spec
-          
+
   - it: should handle custom TTL values correctly
     set:
       fullnameOverride: app
@@ -251,7 +251,7 @@ tests:
           count: 1
       - exists:
           path: spec
-          
+
   - it: should include CorrelationId in test engine payload
     set:
       fullnameOverride: app
@@ -894,4 +894,112 @@ tests:
           count: 1
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
+          pattern: "TestCategory=coretests"
+
+  # ── TestEngine webhook URL selection tests ────────────────────────────────
+
+  - it: should use global.testengineWebhookUrl when injected and no explicit webhook_url
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      global.testengineWebhookUrl: "vault:DevOps/data/testengine/api#dev_url"
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=whatever"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: TESTENGINEHOOK_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api#dev_url"
+
+  - it: should fall back to prod vault key when global.testengineWebhookUrl is not set
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=whatever"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: TESTENGINEHOOK_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api#url"
+
+  - it: should prefer explicit webhook_url over global.testengineWebhookUrl
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      global.testengineWebhookUrl: "vault:DevOps/data/testengine/api#dev_url"
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            webhook_url: "vault:DevOps/data/testengine/api#url"
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=whatever"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: TESTENGINEHOOK_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api#url"
           pattern: '"TestFilters":\s*"TestCategory=coretests"'


### PR DESCRIPTION
## Summary

- `TESTENGINEHOOK_URL` in the test-trigger Job now reads `global.testengineWebhookUrl` (injected by the CI/CD render step) as its default, instead of hard-coding an empty string.
- Services that already have an explicit `webhook_url:` in their values file are **not affected** — the `dig` lookup chain means explicit values always win.
- Hard-coded fallback (when `global.testengineWebhookUrl` is absent, e.g. local render) is `vault:DevOps/data/testengine/api#url` (prod).

## Changes

- **`_spec_triggertestengine.tpl`**: replace empty-string `dig` default with `$.Values.global.testengineWebhookUrl | default "vault:DevOps/data/testengine/api#url"`
- **`TestTriggersGuide.md`**: mark `webhook_url` as optional, document CI/CD auto-injection
- **`tests/triggertests_test.yaml`**: add 3 unit tests:
  - `global.testengineWebhookUrl` is used when no explicit `webhook_url` set
  - Falls back to prod vault key when `global.testengineWebhookUrl` is absent
  - Explicit `webhook_url` in values wins over `global.testengineWebhookUrl`

## How to verify

```
cd charts/mycarrier-helm
helm unittest .
```

All existing tests plus the 3 new `testengine webhook URL selection tests` cases should pass.

## ⚠️ Merge Order

This is a **3-repo change**. Merges must happen in this exact order:

| Step | Repo | PR | Why |
|------|------|----|-----|
| **1 — merge this first** | `helm-charts` | #74 (this PR) | Chart must be released so `global.testengineWebhookUrl` is consumed by services |
| **2 + update chart version** | `workflow-dev` | [#11](https://github.com/MyCarrier-DevOps/workflow-dev/pull/11) | Render step starts injecting `global.testengineWebhookUrl` into helm template |
| **3 — merge last** | `MC.Example` | [#128](https://github.com/MyCarrier-Engineering/MC.Example/pull/128) | Safe to remove explicit `webhook_url` only after steps 1 + 2 are live |

## Checklist
- [x] Build passes
- [x] Tests pass (new + existing)
- [x] Docs updated (`TestTriggersGuide.md`)
- [x] No secrets or credentials committed