### PR TITLE
Feat/krakend operator

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.0.64
+version: 3.1.0
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1078,10 +1078,12 @@ that the CR depends on.
 ### Development workflow
 
 **New public API endpoints must be developed and released directly to `dev`.**
-Because the `.internal` ServiceEntry only exists in non-feature environments,
-feature environments cannot host a `KrakenDAutoConfig` — attempting to render
-one there will fail the Helm template. Iterate on new gateway endpoints
-against `dev` and promote through the normal preprod/prod pipeline.
+Feature environments are intentionally excluded from `KrakenDAutoConfig`
+rendering — attempting to render one there will fail the Helm template.
+Each KAC registers endpoints on the shared `KrakenDGateway`, so per‑feature‑env
+variants of the same application would collide with the dev‑env KAC for
+that application. Iterate on new gateway endpoints against `dev` and
+promote through the normal preprod/prod pipeline.
 
 ### Minimal configuration
 

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1038,6 +1038,94 @@ cronjobs:
 - `"0 0 1 * *"` - Monthly on the 1st
 - `"0 9 * * 1-5"` - Weekdays at 9 AM
 
+## KrakenD AutoConfig
+
+The chart can render a `gateway.krakend.io/v1alpha1` **`KrakenDAutoConfig`** CR
+for any application that opts in via `networking.krakend.enabled: true`. The
+KrakenD operator watches the CR and generates KrakenD endpoints from the
+referenced OpenAPI spec.
+
+### Internal-only guarantee
+
+The rendered CR **only ever references internal addresses**:
+
+- `spec.openapi.url` is always built from the application's `.internal` host:
+
+  ```text
+  http://<baseFullName>.<metaEnv>.internal<path>
+  ```
+
+  e.g. `http://app-routingguide-publicapi.dev.internal/swagger/v1/swagger.json`.
+- `spec.urlTransform.hostMapping` auto-includes catch-all entries that rewrite
+  any external hostname the OpenAPI `servers:` block may advertise back to the
+  internal URL. This means generated backends stay internal even when the
+  upstream spec lists the public domain.
+- User-supplied `extraHostMapping` entries are validated at template time:
+  rendering **fails** if any `to:` value contains the external domain.
+
+### Required prerequisites
+
+KAC rendering requires BOTH of the following — the chart fails the render
+otherwise:
+
+1. `environment.name` is **not** a feature environment.
+2. `networking.istio.internalEnabled` is `true` for the application.
+
+Both are prerequisites for the `.internal` ServiceEntry that the CR depends
+on.
+
+### Development workflow
+
+**New public API endpoints must be developed and released directly to `dev`.**
+Because the `.internal` ServiceEntry only exists in non-feature environments,
+feature environments cannot host a `KrakenDAutoConfig` — attempting to render
+one there will fail the Helm template. Iterate on new gateway endpoints
+against `dev` and promote through the normal preprod/prod pipeline.
+
+### Minimal configuration
+
+```yaml
+applications:
+  routingguide-publicapi:
+    # ... standard deployment configuration ...
+    networking:
+      istio:
+        enabled: true
+        internalEnabled: true
+      krakend:
+        enabled: true
+        gatewayRef:
+          name: mycarrier-public-api
+          namespace: krakend
+```
+
+### Full configuration reference
+
+See the commented example under `networking.krakend` in
+[`values.yaml`](./values.yaml) and the schema in
+[`values.schema.json`](./values.schema.json). Supported fields:
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Render the KAC CR. Default `false`. |
+| `name` | Override `metadata.name`. Default `<fullName>-autoconfig`. |
+| `autoConfigNamespace` | KAC namespace. Defaults to `gatewayRef.namespace` → `global.krakendGatewayNamespace` → app namespace. |
+| `labels` / `annotations` | Extra metadata merged into the KAC CR. |
+| `gatewayRef.name` | **Required.** `KrakenDGateway` name. |
+| `gatewayRef.namespace` | Gateway namespace. Falls back to `global.krakendGatewayNamespace` or the app namespace. |
+| `trigger` | `OnChange` (default) or `Periodic`. |
+| `periodic.interval` | Required when `trigger=Periodic` (e.g. `5m`). |
+| `openapi.path` | Path appended to the internal host. Default `/swagger/v1/swagger.json`. |
+| `openapi.format` | `json` or `yaml`. Auto-detected if omitted. |
+| `openapi.allowClusterLocal` | Default `true`. |
+| `openapi.auth` | Optional bearer/basic auth for the spec fetch. |
+| `urlTransform.stripPathPrefix` / `addPathPrefix` | Path rewrites. |
+| `urlTransform.extraHostMapping` | Additional mappings (appended after auto-generated entries). `to:` **must not** contain the external domain. |
+| `defaults` | Endpoint/backend defaults (mirrors `KrakenDAutoConfigSpec.Defaults`). |
+| `overrides` | Per-operation overrides. |
+| `filter` | Include/exclude by path/method/tag/operationId. |
+| `cue` | Optional CUE definitions / environment. |
+
 ## ArgoCD Integration
 
 The chart includes ArgoCD sync waves and options for better GitOps workflows:

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1120,7 +1120,7 @@ See the commented example under `networking.krakend` in
 | `openapi.allowClusterLocal` | Default `true`. |
 | `openapi.auth` | Optional bearer/basic auth for the spec fetch. |
 | `urlTransform.stripPathPrefix` / `addPathPrefix` | Path rewrites. |
-| `urlTransform.extraHostMapping` | Additional mappings (appended after auto-generated entries). `to:` **must not** contain the external domain. |
+| `urlTransform.extraHostMapping` | Additional mappings (appended after auto-generated entries). `to:` host **must** end in `.internal` or `.svc.cluster.local`; values containing the external domain or non-internal hosts (e.g. IP literals, public hostnames) are rejected at render time. |
 | `defaults` | Endpoint/backend defaults (mirrors `KrakenDAutoConfigSpec.Defaults`). |
 | `overrides` | Per-operation overrides. |
 | `filter` | Include/exclude by path/method/tag/operationId. |

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1065,14 +1065,15 @@ The rendered CR **only ever references internal addresses**:
 
 ### Required prerequisites
 
-KAC rendering requires BOTH of the following — the chart fails the render
-otherwise:
+KAC rendering requires **all** of the following — the chart fails the render
+otherwise. These conditions mirror the gating on the `.internal` ServiceEntry
+that the CR depends on.
 
 1. `environment.name` is **not** a feature environment.
-2. `networking.istio.internalEnabled` is `true` for the application.
-
-Both are prerequisites for the `.internal` ServiceEntry that the CR depends
-on.
+2. `networking.istio.enabled` is `true`.
+3. `istioDisabled` (top-level application flag) is not `true`.
+4. `service.istioDisabled` is not `true`.
+5. `networking.istio.internalEnabled` is `true`.
 
 ### Development workflow
 

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -45,7 +45,7 @@ false
 {{- $serviceIstioDisabled := dig "service" "istioDisabled" false $app -}}
 {{- $internalEnabled := dig "networking" "istio" "internalEnabled" true $app -}}
 {{- if hasPrefix "feature" $envName -}}
-{{- fail (printf "networking.krakend.enabled=true is not supported in feature environments (got environment=%q). The `.internal` ServiceEntry only exists in non-feature environments; new public API endpoints must be developed and released directly to dev." $envName) -}}
+{{- fail (printf "networking.krakend.enabled=true is not supported in feature environments (got environment=%q). Each KrakenDAutoConfig registers endpoints on the shared KrakenDGateway, so per-feature-env variants would collide with the dev-env KrakenDAutoConfig for the same application. New public API endpoints must be developed and released directly to dev." $envName) -}}
 {{- else if not $istioEnabled -}}
 {{- fail (printf "networking.krakend.enabled=true requires networking.istio.enabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when Istio is disabled.") -}}
 {{- else if $appIstioDisabled -}}
@@ -194,17 +194,21 @@ https://public-site, etc.) is rejected as non-internal.
 {{- $extra := dig "networking" "krakend" "urlTransform" "extraHostMapping" (list) $app -}}
 {{- range $i, $entry := $extra -}}
 {{- $to := $entry.to | default "" -}}
-{{- if contains $domain $to -}}
+{{- $domainLower := lower $domain -}}
+{{- $toLower := lower $to -}}
+{{- if contains $domainLower $toLower -}}
 {{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q contains the external domain %q. The KrakenDAutoConfig must only map to internal addresses (.internal or .svc.cluster.local)." $appName $i $to $domain) -}}
 {{- end -}}
-{{- /* Extract the host portion: strip scheme and path/port. */ -}}
+{{- /* Extract the host portion: strip scheme and path/port. Lower-case for
+       suffix comparison so values like `Foo.DEV.Internal` are still accepted. */ -}}
 {{- $host := $to -}}
 {{- if contains "://" $host -}}
 {{- $host = (splitList "://" $host | last) -}}
 {{- end -}}
 {{- $host = (splitList "/" $host | first) -}}
 {{- $host = (splitList ":" $host | first) -}}
-{{- $isInternal := or (hasSuffix ".internal" $host) (hasSuffix ".svc.cluster.local" $host) -}}
+{{- $hostLower := lower $host -}}
+{{- $isInternal := or (hasSuffix ".internal" $hostLower) (hasSuffix ".svc.cluster.local" $hostLower) -}}
 {{- if not $isInternal -}}
 {{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q is not an internal address. The host portion must end in .internal or .svc.cluster.local." $appName $i $to) -}}
 {{- end -}}

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -14,8 +14,20 @@ Guarantees:
 
 {{/*
 helm.krakend.enabled returns "true" when the application has opted in to
-KrakenDAutoConfig rendering AND the required `.internal` ServiceEntry will
-be rendered (non-feature environment, internalEnabled = true).
+KrakenDAutoConfig rendering AND every prerequisite for the `.internal`
+ServiceEntry is satisfied. This mirrors the gating in
+templates/internal-serviceentry.yaml so we never emit a KrakenDAutoConfig
+that points at an internal host that was never created.
+
+Prerequisites (all must hold):
+  - networking.krakend.enabled == true
+  - not a feature environment
+  - networking.istio.enabled == true
+  - istioDisabled != true (top-level application flag)
+  - service.istioDisabled != true
+  - networking.istio.internalEnabled == true
+
+Any violation fails the render with a clear, targeted error.
 
 Usage:
   {{- if eq (include "helm.krakend.enabled" $appContext) "true" }}
@@ -28,9 +40,18 @@ Usage:
 false
 {{- else -}}
 {{- $envName := .Values.environment.name | default "dev" -}}
+{{- $istioEnabled := dig "networking" "istio" "enabled" true $app -}}
+{{- $appIstioDisabled := dig "istioDisabled" false $app -}}
+{{- $serviceIstioDisabled := dig "service" "istioDisabled" false $app -}}
 {{- $internalEnabled := dig "networking" "istio" "internalEnabled" true $app -}}
 {{- if hasPrefix "feature" $envName -}}
 {{- fail (printf "networking.krakend.enabled=true is not supported in feature environments (got environment=%q). The `.internal` ServiceEntry only exists in non-feature environments; new public API endpoints must be developed and released directly to dev." $envName) -}}
+{{- else if not $istioEnabled -}}
+{{- fail (printf "networking.krakend.enabled=true requires networking.istio.enabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when Istio is disabled.") -}}
+{{- else if $appIstioDisabled -}}
+{{- fail (printf "networking.krakend.enabled=true is incompatible with istioDisabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when istioDisabled=true.") -}}
+{{- else if $serviceIstioDisabled -}}
+{{- fail (printf "networking.krakend.enabled=true is incompatible with service.istioDisabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when service.istioDisabled=true.") -}}
 {{- else if not $internalEnabled -}}
 {{- fail (printf "networking.krakend.enabled=true requires networking.istio.internalEnabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when internalEnabled is false.") -}}
 {{- else -}}

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -156,8 +156,15 @@ Priority:
 
 {{/*
 helm.krakend.validateExtraHostMapping fails the render when any user-supplied
-`extraHostMapping` entry's `to:` value contains the external domain. This
-enforces the internal-only invariant at template time.
+`extraHostMapping` entry's `to:` value is not an internal address.
+
+Internal-only invariant: `to:` must either
+  - be a bare hostname ending in `.internal` or `.svc.cluster.local`, or
+  - be an http(s) URL whose host ends in `.internal` or `.svc.cluster.local`.
+
+Values that contain the configured external domain are rejected with a
+dedicated error for clarity. Any other value (example.com, an IP literal,
+https://public-site, etc.) is rejected as non-internal.
 */}}
 {{- define "helm.krakend.validateExtraHostMapping" -}}
 {{- $app := .application -}}
@@ -167,7 +174,18 @@ enforces the internal-only invariant at template time.
 {{- range $i, $entry := $extra -}}
 {{- $to := $entry.to | default "" -}}
 {{- if contains $domain $to -}}
-{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q contains the external domain %q. The KrakenDAutoConfig must only map to internal addresses (svc.cluster.local or .internal)." $appName $i $to $domain) -}}
+{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q contains the external domain %q. The KrakenDAutoConfig must only map to internal addresses (.internal or .svc.cluster.local)." $appName $i $to $domain) -}}
+{{- end -}}
+{{- /* Extract the host portion: strip scheme and path/port. */ -}}
+{{- $host := $to -}}
+{{- if contains "://" $host -}}
+{{- $host = (splitList "://" $host | last) -}}
+{{- end -}}
+{{- $host = (splitList "/" $host | first) -}}
+{{- $host = (splitList ":" $host | first) -}}
+{{- $isInternal := or (hasSuffix ".internal" $host) (hasSuffix ".svc.cluster.local" $host) -}}
+{{- if not $isInternal -}}
+{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q is not an internal address. The host portion must end in .internal or .svc.cluster.local." $appName $i $to) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -201,9 +219,12 @@ trigger: {{ $trigger }}
 periodic:
   interval: {{ $interval | quote }}
 {{- end }}
-{{- /* openapi — always internal */ -}}
+{{- /* openapi — always internal. Normalize path to ensure a leading slash. */ -}}
 {{- $openapi := dig "openapi" dict $krakend -}}
-{{- $path := dig "path" "/swagger/v1/swagger.json" $openapi }}
+{{- $path := dig "path" "/swagger/v1/swagger.json" $openapi -}}
+{{- if and $path (not (hasPrefix "/" $path)) -}}
+{{- $path = printf "/%s" $path -}}
+{{- end }}
 openapi:
   url: {{ printf "%s%s" $internalURL $path | quote }}
   allowClusterLocal: {{ dig "allowClusterLocal" true $openapi }}

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -1,0 +1,267 @@
+{{/*
+Helpers for the KrakenDAutoConfig CR rendered by templates/krakendAutoConfig.yaml.
+
+Guarantees:
+- The generated spec.openapi.url always points at the application's internal
+  address (<baseFullName>.<metaEnv>.internal) and NEVER at the public/external
+  domain, so that KrakenD only ever fetches the OpenAPI spec from a
+  cluster-local endpoint.
+- spec.urlTransform.hostMapping auto-includes catch-all entries that rewrite
+  any external hostname the OpenAPI `servers:` block might advertise back to
+  the internal URL, so that generated backends stay internal regardless of
+  what the upstream spec declares.
+*/}}
+
+{{/*
+helm.krakend.enabled returns "true" when the application has opted in to
+KrakenDAutoConfig rendering AND the required `.internal` ServiceEntry will
+be rendered (non-feature environment, internalEnabled = true).
+
+Usage:
+  {{- if eq (include "helm.krakend.enabled" $appContext) "true" }}
+*/}}
+{{- define "helm.krakend.enabled" -}}
+{{- $app := .application -}}
+{{- $krakend := dig "networking" "krakend" dict $app -}}
+{{- $enabled := dig "enabled" false $krakend -}}
+{{- if not $enabled -}}
+false
+{{- else -}}
+{{- $envName := .Values.environment.name | default "dev" -}}
+{{- $internalEnabled := dig "networking" "istio" "internalEnabled" true $app -}}
+{{- if hasPrefix "feature" $envName -}}
+{{- fail (printf "networking.krakend.enabled=true is not supported in feature environments (got environment=%q). The `.internal` ServiceEntry only exists in non-feature environments; new public API endpoints must be developed and released directly to dev." $envName) -}}
+{{- else if not $internalEnabled -}}
+{{- fail (printf "networking.krakend.enabled=true requires networking.istio.internalEnabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when internalEnabled is false.") -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.krakend.internalHost returns the <baseFullName>.<metaEnv>.internal host
+used for both spec.openapi.url and the urlTransform.hostMapping `to:` side.
+*/}}
+{{- define "helm.krakend.internalHost" -}}
+{{- $baseFullName := include "helm.basename" . -}}
+{{- $metaenv := include "helm.metaEnvironment" . -}}
+{{- printf "%s.%s.internal" $baseFullName $metaenv -}}
+{{- end -}}
+
+{{/*
+helm.krakend.internalURL returns http://<internalHost>. No port is included;
+Istio resolves the host via the internal ServiceEntry and routes to the
+application's http port.
+*/}}
+{{- define "helm.krakend.internalURL" -}}
+{{- printf "http://%s" (include "helm.krakend.internalHost" .) -}}
+{{- end -}}
+
+{{/*
+helm.krakend.externalHosts returns a newline-separated list of external
+hostnames that the application may advertise in its OpenAPI `servers:` block.
+Used to emit catch-all hostMapping entries that rewrite external URLs → the
+internal URL.
+
+Sources (all deduplicated):
+- staticHostname.<domain>         (when .application.staticHostname is set)
+- <appStack>-<appName>.<domainPrefix>.<domain>  (standard external host)
+- every entry in .application.networking.istio.hosts
+*/}}
+{{- define "helm.krakend.externalHosts" -}}
+{{- $app := .application -}}
+{{- $appName := .appName -}}
+{{- $domain := include "helm.domain" . -}}
+{{- $domainPrefix := include "helm.domain.prefix" . -}}
+{{- $appStack := .Values.global.appStack | default "app" -}}
+{{- $hosts := list -}}
+{{- if $app.staticHostname -}}
+{{- $hosts = append $hosts (printf "%s.%s" (trimSuffix "." $app.staticHostname) $domain) -}}
+{{- end -}}
+{{- $standard := printf "%s.%s.%s" ((list $appStack $appName) | join "-" | lower | trunc 63 | trimSuffix "-") $domainPrefix $domain -}}
+{{- $hosts = append $hosts $standard -}}
+{{- $istioHosts := dig "networking" "istio" "hosts" (list) $app -}}
+{{- range $istioHosts -}}
+{{- $hosts = append $hosts . -}}
+{{- end -}}
+{{- $hosts | uniq | join "\n" -}}
+{{- end -}}
+
+{{/*
+helm.krakend.autoConfigName returns the metadata.name for the KAC CR.
+Defaults to <fullName>-autoconfig, truncated to 63 chars.
+*/}}
+{{- define "helm.krakend.autoConfigName" -}}
+{{- $app := .application -}}
+{{- $override := dig "networking" "krakend" "name" "" $app -}}
+{{- if $override -}}
+{{- $override | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-autoconfig" (include "helm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.krakend.autoConfigNamespace returns the namespace the KAC CR is rendered
+into. Priority:
+  1. networking.krakend.autoConfigNamespace
+  2. networking.krakend.gatewayRef.namespace  (colocate with gateway)
+  3. .Values.global.krakendGatewayNamespace
+  4. application namespace
+*/}}
+{{- define "helm.krakend.autoConfigNamespace" -}}
+{{- $app := .application -}}
+{{- $krakend := dig "networking" "krakend" dict $app -}}
+{{- $override := dig "autoConfigNamespace" "" $krakend -}}
+{{- $gatewayNs := dig "gatewayRef" "namespace" "" $krakend -}}
+{{- $globalNs := "" -}}
+{{- if and .Values.global (hasKey (.Values.global | default dict) "krakendGatewayNamespace") -}}
+{{- $globalNs = .Values.global.krakendGatewayNamespace -}}
+{{- end -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else if $gatewayNs -}}
+{{- $gatewayNs -}}
+{{- else if $globalNs -}}
+{{- $globalNs -}}
+{{- else -}}
+{{- include "helm.namespace" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.krakend.gatewayNamespace returns the namespace for spec.gatewayRef.
+Priority:
+  1. networking.krakend.gatewayRef.namespace
+  2. .Values.global.krakendGatewayNamespace
+  3. application namespace
+*/}}
+{{- define "helm.krakend.gatewayNamespace" -}}
+{{- $app := .application -}}
+{{- $krakend := dig "networking" "krakend" dict $app -}}
+{{- $gatewayNs := dig "gatewayRef" "namespace" "" $krakend -}}
+{{- $globalNs := "" -}}
+{{- if and .Values.global (hasKey (.Values.global | default dict) "krakendGatewayNamespace") -}}
+{{- $globalNs = .Values.global.krakendGatewayNamespace -}}
+{{- end -}}
+{{- if $gatewayNs -}}
+{{- $gatewayNs -}}
+{{- else if $globalNs -}}
+{{- $globalNs -}}
+{{- else -}}
+{{- include "helm.namespace" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.krakend.validateExtraHostMapping fails the render when any user-supplied
+`extraHostMapping` entry's `to:` value contains the external domain. This
+enforces the internal-only invariant at template time.
+*/}}
+{{- define "helm.krakend.validateExtraHostMapping" -}}
+{{- $app := .application -}}
+{{- $appName := .appName -}}
+{{- $domain := include "helm.domain" . -}}
+{{- $extra := dig "networking" "krakend" "urlTransform" "extraHostMapping" (list) $app -}}
+{{- range $i, $entry := $extra -}}
+{{- $to := $entry.to | default "" -}}
+{{- if contains $domain $to -}}
+{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q contains the external domain %q. The KrakenDAutoConfig must only map to internal addresses (svc.cluster.local or .internal)." $appName $i $to $domain) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.specs.krakendautoconfig renders the full `spec:` body of the
+KrakenDAutoConfig CR. Expects the standard $appContext dict with keys
+appName, application, Values, ctx.
+*/}}
+{{- define "helm.specs.krakendautoconfig" -}}
+{{- $app := .application -}}
+{{- $appName := .appName -}}
+{{- $krakend := dig "networking" "krakend" dict $app -}}
+{{- $internalURL := include "helm.krakend.internalURL" . -}}
+{{- /* Validate user input up front */ -}}
+{{- include "helm.krakend.validateExtraHostMapping" . -}}
+{{- /* gatewayRef (required) */ -}}
+{{- $gatewayRef := dig "gatewayRef" dict $krakend -}}
+{{- $gatewayName := required (printf "application %q: networking.krakend.gatewayRef.name is required when networking.krakend.enabled=true" $appName) (dig "name" "" $gatewayRef) -}}
+gatewayRef:
+  name: {{ $gatewayName }}
+  namespace: {{ include "helm.krakend.gatewayNamespace" . }}
+{{- /* trigger */ -}}
+{{- $trigger := dig "trigger" "OnChange" $krakend }}
+trigger: {{ $trigger }}
+{{- if eq $trigger "Periodic" }}
+{{- $interval := dig "periodic" "interval" "" $krakend -}}
+{{- if not $interval -}}
+{{- fail (printf "application %q: networking.krakend.periodic.interval is required when trigger=Periodic" $appName) -}}
+{{- end }}
+periodic:
+  interval: {{ $interval | quote }}
+{{- end }}
+{{- /* openapi — always internal */ -}}
+{{- $openapi := dig "openapi" dict $krakend -}}
+{{- $path := dig "path" "/swagger/v1/swagger.json" $openapi }}
+openapi:
+  url: {{ printf "%s%s" $internalURL $path | quote }}
+  allowClusterLocal: {{ dig "allowClusterLocal" true $openapi }}
+{{- if hasKey $openapi "format" }}
+  format: {{ $openapi.format }}
+{{- end }}
+{{- if hasKey $openapi "auth" }}
+  auth:
+{{ toYaml $openapi.auth | indent 4 }}
+{{- end }}
+{{- /* urlTransform — always emitted: identity + catch-all external-host mappings */ -}}
+{{- $urlTransform := dig "urlTransform" dict $krakend -}}
+{{- $externalHostsStr := include "helm.krakend.externalHosts" . -}}
+{{- $externalHosts := list -}}
+{{- if $externalHostsStr -}}
+{{- $externalHosts = splitList "\n" $externalHostsStr -}}
+{{- end -}}
+{{- $extra := dig "extraHostMapping" (list) $urlTransform }}
+urlTransform:
+  hostMapping:
+    - from: {{ $internalURL | quote }}
+      to: {{ $internalURL | quote }}
+{{- range $host := $externalHosts }}
+{{- if $host }}
+    - from: {{ printf "http://%s" $host | quote }}
+      to: {{ $internalURL | quote }}
+    - from: {{ printf "https://%s" $host | quote }}
+      to: {{ $internalURL | quote }}
+{{- end }}
+{{- end }}
+{{- range $entry := $extra }}
+    - from: {{ $entry.from | quote }}
+      to: {{ $entry.to | quote }}
+{{- end }}
+{{- if hasKey $urlTransform "stripPathPrefix" }}
+  stripPathPrefix: {{ $urlTransform.stripPathPrefix | quote }}
+{{- end }}
+{{- if hasKey $urlTransform "addPathPrefix" }}
+  addPathPrefix: {{ $urlTransform.addPathPrefix | quote }}
+{{- end }}
+{{- /* defaults passthrough */ -}}
+{{- if hasKey $krakend "defaults" }}
+defaults:
+{{ toYaml $krakend.defaults | indent 2 }}
+{{- end }}
+{{- /* overrides passthrough */ -}}
+{{- if hasKey $krakend "overrides" }}
+overrides:
+{{ toYaml $krakend.overrides | indent 2 }}
+{{- end }}
+{{- /* filter passthrough */ -}}
+{{- if hasKey $krakend "filter" }}
+filter:
+{{ toYaml $krakend.filter | indent 2 }}
+{{- end }}
+{{- /* cue passthrough */ -}}
+{{- if hasKey $krakend "cue" }}
+cue:
+{{ toYaml $krakend.cue | indent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
+++ b/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
@@ -1,0 +1,40 @@
+{{/*
+KrakenDAutoConfig — one per application that sets networking.krakend.enabled: true.
+
+The operator (gateway.krakend.io/v1alpha1) watches this CR and generates
+KrakenD endpoints from the referenced OpenAPI spec. The spec.openapi.url is
+always built from the application's `.internal` host — never the public
+domain — and urlTransform.hostMapping auto-rewrites any external host the
+OpenAPI `servers:` block may advertise back to the internal URL.
+
+NOTE: KAC rendering requires a non-feature environment AND
+networking.istio.internalEnabled=true, since both conditions are required
+for the `.internal` ServiceEntry to exist. See helm.krakend.enabled.
+*/}}
+{{- $globalCtx := include "helm.context" $ | fromJson -}}
+{{- range $appName, $appValues := .Values.applications }}
+{{- $appContext := (merge (dict "appName" $appName "application" $appValues "ctx" $globalCtx) $) }}
+{{- if eq (include "helm.krakend.enabled" $appContext) "true" }}
+{{- $kacName := include "helm.krakend.autoConfigName" $appContext }}
+{{- $kacNamespace := include "helm.krakend.autoConfigNamespace" $appContext }}
+---
+apiVersion: gateway.krakend.io/v1alpha1
+kind: KrakenDAutoConfig
+metadata:
+  name: {{ $kacName }}
+  namespace: {{ $kacNamespace }}
+  labels:
+    {{ include "helm.labels.standard" $appContext | indent 4 | trim }}
+    {{- with dig "networking" "krakend" "labels" dict $appValues }}
+    {{ toYaml . | indent 4 | trim }}
+    {{- end }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=true
+    {{- with dig "networking" "krakend" "annotations" dict $appValues }}
+    {{ toYaml . | indent 4 | trim }}
+    {{- end }}
+spec:
+  {{ include "helm.specs.krakendautoconfig" $appContext | indent 2 | trim }}
+{{- end }}
+{{- end }}

--- a/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
+++ b/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
@@ -7,9 +7,11 @@ always built from the application's `.internal` host — never the public
 domain — and urlTransform.hostMapping auto-rewrites any external host the
 OpenAPI `servers:` block may advertise back to the internal URL.
 
-NOTE: KAC rendering requires a non-feature environment AND
-networking.istio.internalEnabled=true, since both conditions are required
-for the `.internal` ServiceEntry to exist. See helm.krakend.enabled.
+NOTE: KAC rendering currently requires a non-feature environment,
+networking.istio.enabled=true, networking.istio.internalEnabled=true, and
+neither istioDisabled nor service.istioDisabled set to true. Feature
+environments are intentionally excluded (see helm.krakend.enabled for the
+exact gating logic and rationale).
 */}}
 {{- $globalCtx := include "helm.context" $ | fromJson -}}
 {{- range $appName, $appValues := .Values.applications }}

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -1,0 +1,305 @@
+suite: KrakenDAutoConfig template tests
+templates:
+  - krakendAutoConfig.yaml
+release:
+  name: test
+  namespace: dev
+tests:
+  - it: should not render anything when networking.krakend.enabled is false
+    set:
+      environment.name: dev
+      applications.routingguide-publicapi.image.registry: myregistry.example.com
+      applications.routingguide-publicapi.image.repository: routingguide-publicapi
+      applications.routingguide-publicapi.image.tag: "1.0.0"
+      applications.routingguide-publicapi.ports.http: 8080
+      applications.routingguide-publicapi.networking.istio.enabled: true
+      applications.routingguide-publicapi.networking.istio.internalEnabled: true
+      applications.routingguide-publicapi.networking.krakend.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render anything when networking.krakend is absent
+    set:
+      environment.name: dev
+      applications.routingguide-publicapi.image.registry: myregistry.example.com
+      applications.routingguide-publicapi.image.repository: routingguide-publicapi
+      applications.routingguide-publicapi.image.tag: "1.0.0"
+      applications.routingguide-publicapi.ports.http: 8080
+      applications.routingguide-publicapi.networking.istio.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a minimal KrakenDAutoConfig pointing at the internal address
+    set:
+      environment.name: dev
+      applications.routingguide-publicapi.image.registry: myregistry.example.com
+      applications.routingguide-publicapi.image.repository: routingguide-publicapi
+      applications.routingguide-publicapi.image.tag: "1.0.0"
+      applications.routingguide-publicapi.ports.http: 8080
+      applications.routingguide-publicapi.networking.istio.enabled: true
+      applications.routingguide-publicapi.networking.istio.internalEnabled: true
+      applications.routingguide-publicapi.networking.krakend.enabled: true
+      applications.routingguide-publicapi.networking.krakend.gatewayRef.name: mycarrier-public-api
+      applications.routingguide-publicapi.networking.krakend.gatewayRef.namespace: krakend
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: KrakenDAutoConfig
+      - equal:
+          path: apiVersion
+          value: gateway.krakend.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: app-routingguide-publicapi-autoconfig
+      - equal:
+          path: metadata.namespace
+          value: krakend
+      - equal:
+          path: spec.gatewayRef.name
+          value: mycarrier-public-api
+      - equal:
+          path: spec.gatewayRef.namespace
+          value: krakend
+      - equal:
+          path: spec.trigger
+          value: OnChange
+      - equal:
+          path: spec.openapi.url
+          value: http://app-routingguide-publicapi.dev.internal/swagger/v1/swagger.json
+      - equal:
+          path: spec.openapi.allowClusterLocal
+          value: true
+      - equal:
+          path: spec.urlTransform.hostMapping[0].from
+          value: http://app-routingguide-publicapi.dev.internal
+      - equal:
+          path: spec.urlTransform.hostMapping[0].to
+          value: http://app-routingguide-publicapi.dev.internal
+
+  - it: should include catch-all hostMapping entries for external hosts
+    set:
+      environment.name: dev
+      global.appStack: mycarrier
+      applications.routingguide-publicapi.image.registry: myregistry.example.com
+      applications.routingguide-publicapi.image.repository: routingguide-publicapi
+      applications.routingguide-publicapi.image.tag: "1.0.0"
+      applications.routingguide-publicapi.ports.http: 8080
+      applications.routingguide-publicapi.networking.istio.enabled: true
+      applications.routingguide-publicapi.networking.istio.internalEnabled: true
+      applications.routingguide-publicapi.networking.istio.hosts:
+        - custom.example.com
+      applications.routingguide-publicapi.networking.krakend.enabled: true
+      applications.routingguide-publicapi.networking.krakend.gatewayRef.name: mycarrier-public-api
+    asserts:
+      - contains:
+          path: spec.urlTransform.hostMapping
+          content:
+            from: http://mycarrier-routingguide-publicapi.dev.mycarrier.dev
+            to: http://mycarrier-routingguide-publicapi.dev.internal
+      - contains:
+          path: spec.urlTransform.hostMapping
+          content:
+            from: https://mycarrier-routingguide-publicapi.dev.mycarrier.dev
+            to: http://mycarrier-routingguide-publicapi.dev.internal
+      - contains:
+          path: spec.urlTransform.hostMapping
+          content:
+            from: http://custom.example.com
+            to: http://mycarrier-routingguide-publicapi.dev.internal
+
+  - it: should honor a custom openapi.path
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.openapi.path: /openapi.json
+    asserts:
+      - equal:
+          path: spec.openapi.url
+          value: http://app-api.dev.internal/openapi.json
+
+  - it: should emit periodic interval when trigger=Periodic
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.trigger: Periodic
+      applications.api.networking.krakend.periodic.interval: 5m
+    asserts:
+      - equal:
+          path: spec.trigger
+          value: Periodic
+      - equal:
+          path: spec.periodic.interval
+          value: 5m
+
+  - it: should fail when trigger=Periodic without an interval
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.trigger: Periodic
+    asserts:
+      - failedTemplate:
+          errorMessage: 'application "api": networking.krakend.periodic.interval is required when trigger=Periodic'
+
+  - it: should fail in feature environments
+    set:
+      environment.name: feature-x
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - failedTemplate:
+          errorPattern: 'not supported in feature environments'
+
+  - it: should fail when internalEnabled=false
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: false
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - failedTemplate:
+          errorPattern: 'requires networking.istio.internalEnabled=true'
+
+  - it: should fail when gatewayRef.name is missing
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: 'networking.krakend.gatewayRef.name is required'
+
+  - it: should fail when extraHostMapping.to contains the external domain
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.urlTransform.extraHostMapping:
+        - from: http://legacy
+          to: http://legacy.mycarrier.dev
+    asserts:
+      - failedTemplate:
+          errorPattern: 'contains the external domain'
+
+  - it: should passthrough defaults, overrides, and filter
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.defaults.endpoint.timeout: 30s
+      applications.api.networking.krakend.defaults.endpoint.inputHeaders:
+        - Authorization
+      applications.api.networking.krakend.overrides:
+        - operationId: GetFoo
+          endpoint: /foo
+          timeout: 10s
+      applications.api.networking.krakend.filter.includePaths:
+        - /api/v1/*
+    asserts:
+      - equal:
+          path: spec.defaults.endpoint.timeout
+          value: 30s
+      - equal:
+          path: spec.defaults.endpoint.inputHeaders[0]
+          value: Authorization
+      - equal:
+          path: spec.overrides[0].operationId
+          value: GetFoo
+      - equal:
+          path: spec.overrides[0].endpoint
+          value: /foo
+      - equal:
+          path: spec.filter.includePaths[0]
+          value: /api/v1/*
+
+  - it: should honor autoConfigNamespace override
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.autoConfigNamespace: custom-kac-ns
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.gatewayRef.namespace: krakend
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-kac-ns
+      - equal:
+          path: spec.gatewayRef.namespace
+          value: krakend
+
+  - it: should fall back to global.krakendGatewayNamespace for gatewayRef.namespace
+    set:
+      environment.name: dev
+      global.krakendGatewayNamespace: krakend
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - equal:
+          path: spec.gatewayRef.namespace
+          value: krakend
+      - equal:
+          path: metadata.namespace
+          value: krakend

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -194,6 +194,52 @@ tests:
       - failedTemplate:
           errorPattern: 'requires networking.istio.internalEnabled=true'
 
+  - it: should fail when networking.istio.enabled=false
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: false
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - failedTemplate:
+          errorPattern: 'requires networking.istio.enabled=true'
+
+  - it: should fail when istioDisabled=true
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.istioDisabled: true
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - failedTemplate:
+          errorPattern: 'incompatible with istioDisabled=true'
+
+  - it: should fail when service.istioDisabled=true
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.service.istioDisabled: true
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+    asserts:
+      - failedTemplate:
+          errorPattern: 'incompatible with service.istioDisabled=true'
+
   - it: should fail when gatewayRef.name is missing
     set:
       environment.name: dev

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -272,6 +272,24 @@ tests:
       - failedTemplate:
           errorPattern: 'contains the external domain'
 
+  - it: should fail when extraHostMapping.to contains the external domain in mixed case
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.urlTransform.extraHostMapping:
+        - from: http://legacy
+          to: http://Foo.MyCarrier.Dev
+    asserts:
+      - failedTemplate:
+          errorPattern: 'contains the external domain'
+
   - it: should fail when extraHostMapping.to is a non-internal host (no external domain)
     set:
       environment.name: dev

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -226,6 +226,87 @@ tests:
       - failedTemplate:
           errorPattern: 'contains the external domain'
 
+  - it: should fail when extraHostMapping.to is a non-internal host (no external domain)
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.urlTransform.extraHostMapping:
+        - from: http://legacy
+          to: http://example.com
+    asserts:
+      - failedTemplate:
+          errorPattern: 'is not an internal address'
+
+  - it: should fail when extraHostMapping.to is an IP literal
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.urlTransform.extraHostMapping:
+        - from: http://legacy
+          to: http://10.0.0.5:8080
+    asserts:
+      - failedTemplate:
+          errorPattern: 'is not an internal address'
+
+  - it: should accept extraHostMapping.to ending in .internal or .svc.cluster.local
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.urlTransform.extraHostMapping:
+        - from: http://legacy-a
+          to: http://other.dev.internal
+        - from: http://legacy-b
+          to: other-service.dev.svc.cluster.local:8080
+    asserts:
+      - contains:
+          path: spec.urlTransform.hostMapping
+          content:
+            from: http://legacy-a
+            to: http://other.dev.internal
+      - contains:
+          path: spec.urlTransform.hostMapping
+          content:
+            from: http://legacy-b
+            to: other-service.dev.svc.cluster.local:8080
+
+  - it: should normalize openapi.path when the leading slash is missing
+    set:
+      environment.name: dev
+      applications.api.image.registry: r
+      applications.api.image.repository: api
+      applications.api.image.tag: "1"
+      applications.api.ports.http: 8080
+      applications.api.networking.istio.enabled: true
+      applications.api.networking.istio.internalEnabled: true
+      applications.api.networking.krakend.enabled: true
+      applications.api.networking.krakend.gatewayRef.name: gw
+      applications.api.networking.krakend.openapi.path: openapi.json
+    asserts:
+      - equal:
+          path: spec.openapi.url
+          value: http://app-api.dev.internal/openapi.json
+
   - it: should passthrough defaults, overrides, and filter
     set:
       environment.name: dev

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -831,7 +831,153 @@
                     ]
                   },
                   "krakend": {
-                    "type": "object"
+                    "type": "object",
+                    "description": "KrakenDAutoConfig CR configuration. When enabled=true the chart renders a gateway.krakend.io/v1alpha1 KrakenDAutoConfig for the application. Requires a non-feature environment AND networking.istio.internalEnabled=true.",
+                    "additionalProperties": false,
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Render a KrakenDAutoConfig CR for this application."
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Override the KrakenDAutoConfig metadata.name. Defaults to <fullName>-autoconfig."
+                      },
+                      "autoConfigNamespace": {
+                        "type": "string",
+                        "description": "Namespace the KrakenDAutoConfig CR is rendered into. Defaults to gatewayRef.namespace → global.krakendGatewayNamespace → application namespace."
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                      },
+                      "annotations": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                      },
+                      "gatewayRef": {
+                        "type": "object",
+                        "required": ["name"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "KrakenDGateway metadata.name to attach generated endpoints to."
+                          },
+                          "namespace": {
+                            "type": "string",
+                            "description": "Gateway namespace. Falls back to global.krakendGatewayNamespace or the application namespace."
+                          }
+                        }
+                      },
+                      "trigger": {
+                        "type": "string",
+                        "enum": ["OnChange", "Periodic"],
+                        "default": "OnChange"
+                      },
+                      "periodic": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "interval": {
+                            "type": "string",
+                            "description": "Poll interval (Go duration, e.g. 5m). Required when trigger=Periodic."
+                          }
+                        }
+                      },
+                      "openapi": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "OpenAPI spec source. Note: the URL itself is auto-generated from the application's `.internal` address; only the path component is user-configurable.",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "default": "/swagger/v1/swagger.json",
+                            "description": "Path portion appended to http://<app>.<metaEnv>.internal. Defaults to /swagger/v1/swagger.json."
+                          },
+                          "format": {
+                            "type": "string",
+                            "enum": ["json", "yaml"],
+                            "description": "Spec format. Auto-detected if omitted."
+                          },
+                          "allowClusterLocal": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "auth": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional authentication configuration for the spec fetch (BearerTokenSecret or BasicAuthSecret)."
+                          }
+                        }
+                      },
+                      "urlTransform": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "stripPathPrefix": { "type": "string" },
+                          "addPathPrefix": { "type": "string" },
+                          "extraHostMapping": {
+                            "type": "array",
+                            "description": "Additional host mappings appended AFTER the auto-generated identity + catch-all entries. The `to:` value must not contain the external domain; rendering fails otherwise.",
+                            "items": {
+                              "type": "object",
+                              "required": ["from", "to"],
+                              "additionalProperties": false,
+                              "properties": {
+                                "from": { "type": "string" },
+                                "to": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "defaults": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Default values for generated endpoints and backends. Mirrors KrakenDAutoConfigSpec.Defaults."
+                      },
+                      "overrides": {
+                        "type": "array",
+                        "description": "Per-operation overrides. Mirrors KrakenDAutoConfigSpec.Overrides.",
+                        "items": {
+                          "type": "object",
+                          "required": ["operationId"],
+                          "additionalProperties": true,
+                          "properties": {
+                            "operationId": { "type": "string" }
+                          }
+                        }
+                      },
+                      "filter": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "includePaths": { "type": "array", "items": { "type": "string" } },
+                          "excludePaths": { "type": "array", "items": { "type": "string" } },
+                          "includeMethods": { "type": "array", "items": { "type": "string" } },
+                          "excludeOperationIds": { "type": "array", "items": { "type": "string" } },
+                          "includeTags": { "type": "array", "items": { "type": "string" } },
+                          "excludeTags": { "type": "array", "items": { "type": "string" } }
+                        }
+                      },
+                      "cue": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "environment": { "type": "string" },
+                          "definitionsConfigMapRef": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "name": { "type": "string" },
+                              "key": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               },

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -832,7 +832,7 @@
                   },
                   "krakend": {
                     "type": "object",
-                    "description": "KrakenDAutoConfig CR configuration. When enabled=true the chart renders a gateway.krakend.io/v1alpha1 KrakenDAutoConfig for the application. Requires a non-feature environment AND networking.istio.internalEnabled=true.",
+                    "description": "KrakenDAutoConfig CR configuration. When enabled=true the chart renders a gateway.krakend.io/v1alpha1 KrakenDAutoConfig for the application. Requires a non-feature environment, networking.istio.enabled=true, networking.istio.internalEnabled=true, and neither istioDisabled nor service.istioDisabled may be true. See the helm.krakend.enabled helper for the exact gating.",
                     "additionalProperties": false,
                     "properties": {
                       "enabled": {

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -301,7 +301,7 @@ applications: {}
 #         addPathPrefix: /api/v1/routing  # optional
 #         # extraHostMapping:             # optional; additional mappings appended after the auto-generated ones.
 #         #   - from: "http://some-other-host"
-#         #     to:   "http://<app>.dev.internal"   # must NOT contain the public domain
+#         #     to:   "http://<app>.dev.internal"   # host MUST end in .internal or .svc.cluster.local
 #       defaults:                         # optional; matches KrakenDAutoConfigSpec.Defaults
 #         endpoint:
 #           timeout: 30s

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -254,7 +254,80 @@ applications: {}
 #       #   - "/custom-endpoint"
 #       #   - "/api/v1/*"
 #       # disableDefaultEndpoints: false  # Set true to disable auto C# endpoints
-#   
+#
+#     # ------------------------------------------------------------------------
+#     # KrakenD AutoConfig
+#     # ------------------------------------------------------------------------
+#     # Opt the application in to generating a `gateway.krakend.io/v1alpha1`
+#     # KrakenDAutoConfig CR. The operator uses the CR to generate KrakenD
+#     # endpoints from the referenced OpenAPI spec.
+#     #
+#     # Requirements (enforced at template time):
+#     #   - environment.name is NOT a feature environment (rendering fails)
+#     #   - networking.istio.internalEnabled is true (rendering fails otherwise)
+#     #
+#     # Development workflow: because the `.internal` ServiceEntry only exists
+#     # in non-feature environments, new public API endpoints must be developed
+#     # and released directly to dev. Feature environments cannot host a
+#     # KrakenDAutoConfig.
+#     #
+#     # Guarantees:
+#     #   - spec.openapi.url is always http://<app>.<metaEnv>.internal/<path>
+#     #   - spec.urlTransform.hostMapping auto-includes catch-all entries that
+#     #     rewrite any external host from the OpenAPI `servers:` block back
+#     #     to the internal URL.
+#     krakend:
+#       enabled: false
+#       # name: custom-kac-name            # optional; defaults to <fullName>-autoconfig
+#       # autoConfigNamespace: krakend     # optional; defaults to gatewayRef.namespace → global.krakendGatewayNamespace → app namespace
+#       # labels: {}                       # extra labels for the KAC metadata
+#       # annotations: {}                  # extra annotations for the KAC metadata
+#       gatewayRef:
+#         name: mycarrier-public-api      # required: KrakenDGateway metadata.name
+#         # namespace: krakend            # optional; falls back to global.krakendGatewayNamespace or app namespace
+#       trigger: OnChange                 # OnChange (default) or Periodic
+#       # periodic:
+#       #   interval: 5m                  # required when trigger=Periodic
+#       openapi:
+#         path: /swagger/v1/swagger.json  # optional; default /swagger/v1/swagger.json
+#         # format: json                  # optional: json | yaml (auto-detected if omitted)
+#         # allowClusterLocal: true       # default true
+#         # auth:                         # optional authentication for the spec fetch
+#         #   bearerTokenSecret:
+#         #     name: my-secret
+#         #     key: token
+#       urlTransform:
+#         stripPathPrefix: /api/v1        # optional
+#         addPathPrefix: /api/v1/routing  # optional
+#         # extraHostMapping:             # optional; additional mappings appended after the auto-generated ones.
+#         #   - from: "http://some-other-host"
+#         #     to:   "http://<app>.dev.internal"   # must NOT contain the public domain
+#       defaults:                         # optional; matches KrakenDAutoConfigSpec.Defaults
+#         endpoint:
+#           timeout: 30s
+#           inputHeaders:
+#             - Authorization
+#             - Content-Type
+#         # backend:
+#         #   encoding: json
+#         # policyRef:
+#         #   name: default-policy
+#       overrides: []                     # optional; list of OperationOverride
+#       # overrides:
+#       #   - operationId: GetFoo
+#       #     endpoint: /foo
+#       #     timeout: 10s
+#       filter: {}                        # optional; include/exclude paths/methods/tags/operationIds
+#       # filter:
+#       #   includePaths: ["/api/v1/*"]
+#       #   excludeOperationIds: ["debug-only"]
+#       cue: {}                           # optional; custom CUE definitions ref / environment
+#       # cue:
+#       #   environment: dev
+#       #   definitionsConfigMapRef:
+#       #     name: my-cue-defs
+#       #     key: defs.cue
+#
 #   # ----------------------------------------------------------------------------
 #   # Service Account
 #   # ----------------------------------------------------------------------------

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -258,18 +258,24 @@ applications: {}
 #     # ------------------------------------------------------------------------
 #     # KrakenD AutoConfig
 #     # ------------------------------------------------------------------------
-#     # Opt the application in to generating a `gateway.krakend.io/v1alpha1`
+#     # Opt the application into generating a `gateway.krakend.io/v1alpha1`
 #     # KrakenDAutoConfig CR. The operator uses the CR to generate KrakenD
 #     # endpoints from the referenced OpenAPI spec.
 #     #
 #     # Requirements (enforced at template time):
 #     #   - environment.name is NOT a feature environment (rendering fails)
+#     #   - networking.istio.enabled is true (rendering fails otherwise)
 #     #   - networking.istio.internalEnabled is true (rendering fails otherwise)
+#     #   - istioDisabled is not true (rendering fails otherwise)
+#     #   - service.istioDisabled is not true (rendering fails otherwise)
+#     # See `helm.krakend.enabled` for the exact gating logic.
 #     #
-#     # Development workflow: because the `.internal` ServiceEntry only exists
-#     # in non-feature environments, new public API endpoints must be developed
-#     # and released directly to dev. Feature environments cannot host a
-#     # KrakenDAutoConfig.
+#     # Development workflow: feature environments are intentionally excluded
+#     # from KrakenDAutoConfig rendering. New public API endpoints must be
+#     # developed and released directly to dev rather than validated via a
+#     # feature environment, because each KrakenDAutoConfig registers
+#     # endpoints on the shared KrakenDGateway and per-feature-env variants
+#     # would collide on the same gateway.
 #     #
 #     # Guarantees:
 #     #   - spec.openapi.url is always http://<app>.<metaEnv>.internal/<path>


### PR DESCRIPTION
This pull request introduces first-class support for rendering a `KrakenDAutoConfig` custom resource (CR) in the `mycarrier-helm` chart, enabling automatic gateway configuration for applications that opt in. The implementation guarantees that all generated configuration references only internal addresses, enforces strict validation to prevent exposure of external domains, and provides comprehensive documentation and helper templates to support the new functionality.

**KrakenDAutoConfig support and internal-only guarantees:**

* Added a new template (`krakendAutoConfig.yaml`) that renders a `KrakenDAutoConfig` CR for each application with `networking.krakend.enabled: true`, ensuring that all referenced OpenAPI specs and generated endpoints use only internal addresses and never public domains. Strict validation is performed at template time to prevent accidental exposure of external domains.
* Introduced helper templates in `_helpers_krakend.tpl` to encapsulate logic for determining internal/external hosts, validating configuration, and constructing the CR spec. These helpers enforce internal-only guarantees and simplify future maintenance.

**Documentation and configuration:**

* Added detailed documentation to `README.md` describing how to enable and configure `KrakenDAutoConfig`, the internal-only guarantee, required prerequisites, development workflow, and a full configuration reference.

**Chart versioning:**

* Bumped chart version to `3.1.0` to reflect the addition of this new feature.