### PR TITLE
chore(crossplane): use inf-prod-servicebus-prem as default prod Service Bus name [skip-flagcheck]

### DIFF
--- a/charts/mycarrier-helm/docs/crossplane-infrastructure.md
+++ b/charts/mycarrier-helm/docs/crossplane-infrastructure.md
@@ -34,6 +34,8 @@ infrastructure:
 
 Both examples produce fully configured Crossplane resources with auto-generated names, `Standard` SKU, `Observe` management policy, and `default` provider config. Location must be set either per-resource or via `infrastructure.azure.defaults.location`.
 
+**Note:** The default Service Bus name for `prod` is `inf-prod-servicebus-prem` (Premium SKU namespace). For all other environments it follows the `inf-{env}-servicebus` pattern.
+
 **Note:** Feature environments (`feature-*`) are skipped and do not provision infrastructure. All other environments (dev, preprod, prod, qa, uat, etc.) create resources normally.
 
 ## Global Defaults
@@ -75,7 +77,7 @@ For an app with `global.appStack: myapp`:
 | Resource | dev | preprod | prod |
 |----------|-----|---------|------|
 | Resource Group name | `inf-dev` | `inf-preprod` | `inf-prod` |
-| Service Bus name | `inf-dev-servicebus` | `inf-preprod-servicebus` | `inf-prod-servicebus` |
+| Service Bus name | `inf-dev-servicebus` | `inf-preprod-servicebus` | `inf-prod-servicebus-prem` |
 | Service Bus RG ref | `inf-dev` | `inf-preprod` | `inf-prod` |
 | Storage account | `stmyappdev` | `stmyapppreprod` | `stmyappprod` |
 | K8s namespace | `dev` | `preprod` | `prod` |

--- a/charts/mycarrier-helm/templates/_helpers.crossplane.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.crossplane.tpl
@@ -112,12 +112,17 @@ Usage: {{ include "helm.azure.resourceGroup.defaultName" (dict "root" $root) }}
 {{/*
 Generate default Service Bus namespace name based on environment.
 Uses metaEnvironment to map feature-* environments to "dev".
-Output: inf-{metaEnv}-servicebus (e.g., inf-dev-servicebus, inf-preprod-servicebus, inf-prod-servicebus)
+Output: inf-{metaEnv}-servicebus (e.g., inf-dev-servicebus, inf-preprod-servicebus, inf-prod-servicebus-prem)
+Note: prod uses the Premium-tier namespace inf-prod-servicebus-prem.
 Usage: {{ include "helm.azure.servicebus.name" (dict "root" $root) }}
 */}}
 {{- define "helm.azure.servicebus.name" -}}
 {{- $metaEnv := include "helm.metaEnvironment" .root -}}
+{{- if eq $metaEnv "prod" -}}
+{{- printf "inf-%s-servicebus-prem" $metaEnv -}}
+{{- else -}}
 {{- printf "inf-%s-servicebus" $metaEnv -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/mycarrier-helm/tests/crossplane_azure_servicebus_test.yaml
+++ b/charts/mycarrier-helm/tests/crossplane_azure_servicebus_test.yaml
@@ -1001,7 +1001,46 @@ tests:
           value: "preprod-prepname-inf-preprod-servicebus"
         documentIndex: 0
 
-  # Test 23: Global defaults for providerConfigRef
+  # Test 23: Default servicebus name for prod environment (Premium namespace)
+  - it: should default servicebus name to inf-prod-servicebus-prem for prod
+    set:
+      global.appStack: prodname
+      global.language: csharp
+      environment.name: prod
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          servicebus:
+            - location: "East US"
+              sku: "Premium"
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: "prod-prodname-inf-prod-servicebus-prem"
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["crossplane.io/external-name"]
+          value: "inf-prod-servicebus-prem"
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["servicebus.mycarrier.io/namespace"]
+          value: "inf-prod-servicebus-prem"
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: "prod-prodname-inf-prod-servicebus-prem-orders"
+        documentIndex: 1
+
+  # Test 24: Global defaults for providerConfigRef
   - it: should use global defaults for providerConfigRef when set
     set:
       global.appStack: gdeftest
@@ -1039,7 +1078,7 @@ tests:
           value: "global-provider"
         documentIndex: 2
 
-  # Test 24: Per-resource providerConfigRef overrides global default
+  # Test 25: Per-resource providerConfigRef overrides global default
   - it: should override global providerConfigRef with per-resource value
     set:
       global.appStack: overtest
@@ -1070,7 +1109,7 @@ tests:
           value: "specific-provider"
         documentIndex: 0
 
-  # Test 25: Global default location
+  # Test 26: Global default location
   - it: should use global default location when per-resource location is omitted
     set:
       global.appStack: loctest
@@ -1099,7 +1138,7 @@ tests:
           value: "West Europe"
         documentIndex: 0
 
-  # Test 26: SKU defaults to Standard
+  # Test 27: SKU defaults to Standard
   - it: should default SKU to Standard when not specified
     set:
       global.appStack: skutest
@@ -1125,7 +1164,7 @@ tests:
           value: "Standard"
         documentIndex: 0
 
-  # Test 27: Fully minimal config - all defaults
+  # Test 28: Fully minimal config - all defaults
   - it: should work with fully minimal config using all defaults
     set:
       global.appStack: minimal
@@ -1199,7 +1238,7 @@ tests:
           value: 10
         documentIndex: 2
 
-  # Test 28: Namespace defaults to environment.name
+  # Test 29: Namespace defaults to environment.name
   - it: should default namespace to environment name not env-appStack
     set:
       global.appStack: nsdeftest
@@ -1241,7 +1280,7 @@ tests:
           value: preprod
         documentIndex: 3
 
-  # Test 29: Wildcard (*) managementPolicies should be blocked (schema rejects before template)
+  # Test 30: Wildcard (*) managementPolicies should be blocked (schema rejects before template)
   - it: should fail when wildcard managementPolicies is used on namespace
     set:
       global.appStack: wildcard
@@ -1265,7 +1304,7 @@ tests:
     asserts:
       - failedTemplate: {}
 
-  # Test 30: ServiceBusNamespace should have servicebus.mycarrier.io/namespace label
+  # Test 31: ServiceBusNamespace should have servicebus.mycarrier.io/namespace label
   - it: should add namespace label to ServiceBusNamespace for topic selector disambiguation
     set:
       global.appStack: nslabel
@@ -1298,7 +1337,7 @@ tests:
           value: "labeled-sb"
         documentIndex: 1
 
-  # Test 31: Topic without subscriptions (forward-target pattern)
+  # Test 32: Topic without subscriptions (forward-target pattern)
   - it: should create namespace, two topics, and only a source-topic subscription when the forward-target topic has no subscriptions
     set:
       global.appStack: fwdtarget


### PR DESCRIPTION
## Summary

- The prod Azure Service Bus namespace was renamed to the Premium SKU instance `inf-prod-servicebus-prem`. The chart's auto-generated default name was still pointing to the old `inf-prod-servicebus`, causing Crossplane to target the wrong namespace in prod.

## Changes

- **`templates/_helpers.crossplane.tpl`**: `helm.azure.servicebus.name` now returns `inf-prod-servicebus-prem` when `metaEnv == prod`; all other environments (`dev`, `preprod`, `feature-*`) continue using the `inf-{env}-servicebus` pattern.
- **`docs/crossplane-infrastructure.md`**: Updated per-environment defaults table and added a callout note explaining the prod naming exception.
- **`tests/crossplane_azure_servicebus_test.yaml`**: Added Test 23 — verifies prod renders `inf-prod-servicebus-prem` as both the K8s `metadata.name` and `crossplane.io/external-name`, and that all child topics/subscriptions inherit the correct `servicebus.mycarrier.io/namespace` label. Tests 23–31 renumbered to 24–32.

## Environment behaviour

| Environment | Default Service Bus name |
|-------------|--------------------------|
| dev / feature-* | `inf-dev-servicebus` (unchanged) |
| preprod | `inf-preprod-servicebus` (unchanged) |
| **prod** | **`inf-prod-servicebus-prem`** ← changed |

Explicit `name:` on a servicebus entry always overrides the default.

## How to verify

1. Template render for prod — expect `inf-prod-servicebus-prem`:
   ```sh
   helm template test charts/mycarrier-helm \
     --set global.appStack=myapp --set global.language=csharp \
     --set environment.name=prod \
     --set "infrastructure.azure.defaults.location=East US" \
     --set "infrastructure.azure.servicebus[0].topics[0].name=orders" \
     --set "infrastructure.azure.servicebus[0].topics[0].subscriptions[0].name=proc" \
     --show-only templates/crossplane/azure/servicebus/servicebus.yaml \
     | grep external-name
   ```
2. Template render for dev — expect `inf-dev-servicebus` (no regression):
   ```sh
   helm template test charts/mycarrier-helm \
     --set global.appStack=myapp --set global.language=csharp \
     --set environment.name=dev \
     --set "infrastructure.azure.defaults.location=East US" \
     --set "infrastructure.azure.servicebus[0].topics[0].name=orders" \
     --set "infrastructure.azure.servicebus[0].topics[0].subscriptions[0].name=proc" \
     --show-only templates/crossplane/azure/servicebus/servicebus.yaml \
     | grep external-name
   ```

## Checklist
- [x] Build passes
- [x] Tests pass (new Test 23 added; existing tests unaffected)
- [x] Docs updated
- [x] No secrets or credentials committed
- [x] No breaking changes for dev/preprod environments