### PR TITLE
Fix/krakend autoconfig bugs

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1056,11 +1056,11 @@ The rendered CR **only ever references internal addresses**:
   ```
 
   e.g. `http://app-routingguide-publicapi.dev.internal/swagger/v1/swagger.json`.
-- `spec.urlTransform.hostMapping` auto-includes catch-all entries that rewrite
-  any external hostname the OpenAPI `servers:` block may advertise back to the
-  internal URL. This means generated backends stay internal even when the
-  upstream spec lists the public domain.
+- The chart does **not** auto-generate `urlTransform.hostMapping` entries.
+  The block is omitted entirely unless the user configures `stripPathPrefix`,
+  `addPathPrefix`, or `extraHostMapping`.
 - User-supplied `extraHostMapping` entries are validated at template time:
+  the `to:` host **must** end in `.internal` or `.svc.cluster.local`, and
   rendering **fails** if any `to:` value contains the external domain.
 
 ### Required prerequisites
@@ -1123,7 +1123,7 @@ See the commented example under `networking.krakend` in
 | `openapi.allowClusterLocal` | Default `true`. |
 | `openapi.auth` | Optional bearer/basic auth for the spec fetch. |
 | `urlTransform.stripPathPrefix` / `addPathPrefix` | Path rewrites. |
-| `urlTransform.extraHostMapping` | Additional mappings (appended after auto-generated entries). `to:` host **must** end in `.internal` or `.svc.cluster.local`; values containing the external domain or non-internal hosts (e.g. IP literals, public hostnames) are rejected at render time. |
+| `urlTransform.extraHostMapping` | Additional host mappings emitted under `spec.urlTransform.hostMapping`. `to:` host **must** end in `.internal` or `.svc.cluster.local`; values containing the external domain or non-internal hosts (e.g. IP literals, public hostnames) are rejected at render time. When omitted, no `hostMapping` is emitted. |
 | `defaults` | Endpoint/backend defaults (mirrors `KrakenDAutoConfigSpec.Defaults`). |
 | `overrides` | Per-operation overrides. |
 | `filter` | Include/exclude by path/method/tag/operationId. |

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -161,17 +161,38 @@ https://public-site, etc.) is rejected as non-internal.
 {{- $app := .application -}}
 {{- $appName := .appName -}}
 {{- $domain := include "helm.domain" . -}}
-{{- $extra := dig "networking" "krakend" "urlTransform" "extraHostMapping" (list) $app -}}
-{{- range $i, $entry := $extra -}}
+{{- $urlTransform := dig "networking" "krakend" "urlTransform" dict $app -}}
+{{- $entries := concat (dig "hostMapping" (list) $urlTransform) (dig "extraHostMapping" (list) $urlTransform) -}}
+{{- range $i, $entry := $entries -}}
 {{- $to := $entry.to | default "" -}}
-{{- $domainLower := lower $domain -}}
-{{- $toLower := lower $to -}}
-{{- if contains $domainLower $toLower -}}
-{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q contains the external domain %q. The KrakenDAutoConfig must only map to internal addresses (.internal or .svc.cluster.local)." $appName $i $to $domain) -}}
+{{- include "helm.krakend.validateInternalAddress" (dict "value" $to "domain" $domain "context" (printf "application %q: networking.krakend.urlTransform[%d].to" $appName $i)) -}}
 {{- end -}}
-{{- /* Extract the host portion: strip scheme and path/port. Lower-case for
-       suffix comparison so values like `Foo.DEV.Internal` are still accepted. */ -}}
-{{- $host := $to -}}
+{{- /* Validate user-supplied openapi.url is also internal-only. */ -}}
+{{- $url := dig "networking" "krakend" "openapi" "url" "" $app -}}
+{{- if $url -}}
+{{- include "helm.krakend.validateInternalAddress" (dict "value" $url "domain" $domain "context" (printf "application %q: networking.krakend.openapi.url" $appName)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+helm.krakend.validateInternalAddress fails the render when `value` is not an
+internal address. Internal-only invariant: value must either
+  - be a bare hostname ending in `.internal` or `.svc.cluster.local`, or
+  - be an http(s) URL whose host ends in `.internal` or `.svc.cluster.local`.
+
+Values that contain the configured external domain are rejected with a
+dedicated error for clarity.
+*/}}
+{{- define "helm.krakend.validateInternalAddress" -}}
+{{- $value := .value -}}
+{{- $domain := .domain -}}
+{{- $context := .context -}}
+{{- $domainLower := lower $domain -}}
+{{- $valueLower := lower $value -}}
+{{- if and $domain (contains $domainLower $valueLower) -}}
+{{- fail (printf "%s=%q contains the external domain %q. The KrakenDAutoConfig must only reference internal addresses (.internal or .svc.cluster.local)." $context $value $domain) -}}
+{{- end -}}
+{{- $host := $value -}}
 {{- if contains "://" $host -}}
 {{- $host = (splitList "://" $host | last) -}}
 {{- end -}}
@@ -180,8 +201,7 @@ https://public-site, etc.) is rejected as non-internal.
 {{- $hostLower := lower $host -}}
 {{- $isInternal := or (hasSuffix ".internal" $hostLower) (hasSuffix ".svc.cluster.local" $hostLower) -}}
 {{- if not $isInternal -}}
-{{- fail (printf "application %q: networking.krakend.urlTransform.extraHostMapping[%d].to=%q is not an internal address. The host portion must end in .internal or .svc.cluster.local." $appName $i $to) -}}
-{{- end -}}
+{{- fail (printf "%s=%q is not an internal address. The host portion must end in .internal or .svc.cluster.local." $context $value) -}}
 {{- end -}}
 {{- end -}}
 
@@ -214,14 +234,26 @@ trigger: {{ $trigger }}
 periodic:
   interval: {{ $interval | quote }}
 {{- end }}
-{{- /* openapi — always internal. Normalize path to ensure a leading slash. */ -}}
+{{- /* openapi — URL is auto-generated from the application's `.internal`
+       address by default. Users may override by supplying `openapi.url`
+       (passthrough of the CRD field) or load from a ConfigMap via
+       `openapi.configMapRef`. Path is normalized to ensure a leading slash. */ -}}
 {{- $openapi := dig "openapi" dict $krakend -}}
+{{- $userURL := dig "url" "" $openapi -}}
+{{- $configMapRef := dig "configMapRef" dict $openapi -}}
 {{- $path := dig "path" "/swagger/v1/swagger.json" $openapi -}}
 {{- if and $path (not (hasPrefix "/" $path)) -}}
 {{- $path = printf "/%s" $path -}}
 {{- end }}
 openapi:
+{{- if $userURL }}
+  url: {{ $userURL | quote }}
+{{- else if not (empty $configMapRef) }}
+  configMapRef:
+{{ toYaml $configMapRef | indent 4 }}
+{{- else }}
   url: {{ printf "%s%s" $internalURL $path | quote }}
+{{- end }}
   allowClusterLocal: {{ dig "allowClusterLocal" true $openapi }}
 {{- if hasKey $openapi "format" }}
   format: {{ $openapi.format }}
@@ -230,22 +262,21 @@ openapi:
   auth:
 {{ toYaml $openapi.auth | indent 4 }}
 {{- end }}
-{{- /* urlTransform — only emitted when the user actually configured something.
-       The previously auto-generated identity entry was a no-op, and the
-       auto-generated external-host catch-all entries were never matched in
-       practice (.NET swagger specs advertise the host they were fetched from,
-       which is already the internal address). Users who do need to rewrite
-       extra hosts can supply them via networking.krakend.urlTransform.extraHostMapping. */ -}}
+{{- /* urlTransform — emitted only when the user actually configured something.
+       Both `hostMapping` (CRD passthrough) and `extraHostMapping` (legacy alias)
+       are accepted; entries are concatenated in that order. The chart never
+       auto-generates host mapping entries — .NET swagger specs advertise the
+       host they were fetched from, which is already the internal address. */ -}}
 {{- $urlTransform := dig "urlTransform" dict $krakend -}}
-{{- $extra := dig "extraHostMapping" (list) $urlTransform -}}
+{{- $hostMappings := concat (dig "hostMapping" (list) $urlTransform) (dig "extraHostMapping" (list) $urlTransform) -}}
 {{- $hasStripPath := hasKey $urlTransform "stripPathPrefix" -}}
 {{- $hasAddPath := hasKey $urlTransform "addPathPrefix" -}}
-{{- $hasExtra := gt (len $extra) 0 -}}
-{{- if or $hasStripPath $hasAddPath $hasExtra }}
+{{- $hasHostMapping := gt (len $hostMappings) 0 -}}
+{{- if or $hasStripPath $hasAddPath $hasHostMapping }}
 urlTransform:
-{{- if $hasExtra }}
+{{- if $hasHostMapping }}
   hostMapping:
-{{- range $entry := $extra }}
+{{- range $entry := $hostMappings }}
     - from: {{ $entry.from | quote }}
       to: {{ $entry.to | quote }}
 {{- end }}

--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -80,36 +80,6 @@ application's http port.
 {{- end -}}
 
 {{/*
-helm.krakend.externalHosts returns a newline-separated list of external
-hostnames that the application may advertise in its OpenAPI `servers:` block.
-Used to emit catch-all hostMapping entries that rewrite external URLs → the
-internal URL.
-
-Sources (all deduplicated):
-- staticHostname.<domain>         (when .application.staticHostname is set)
-- <appStack>-<appName>.<domainPrefix>.<domain>  (standard external host)
-- every entry in .application.networking.istio.hosts
-*/}}
-{{- define "helm.krakend.externalHosts" -}}
-{{- $app := .application -}}
-{{- $appName := .appName -}}
-{{- $domain := include "helm.domain" . -}}
-{{- $domainPrefix := include "helm.domain.prefix" . -}}
-{{- $appStack := .Values.global.appStack | default "app" -}}
-{{- $hosts := list -}}
-{{- if $app.staticHostname -}}
-{{- $hosts = append $hosts (printf "%s.%s" (trimSuffix "." $app.staticHostname) $domain) -}}
-{{- end -}}
-{{- $standard := printf "%s.%s.%s" ((list $appStack $appName) | join "-" | lower | trunc 63 | trimSuffix "-") $domainPrefix $domain -}}
-{{- $hosts = append $hosts $standard -}}
-{{- $istioHosts := dig "networking" "istio" "hosts" (list) $app -}}
-{{- range $istioHosts -}}
-{{- $hosts = append $hosts . -}}
-{{- end -}}
-{{- $hosts | uniq | join "\n" -}}
-{{- end -}}
-
-{{/*
 helm.krakend.autoConfigName returns the metadata.name for the KAC CR.
 Defaults to <fullName>-autoconfig, truncated to 63 chars.
 */}}
@@ -260,35 +230,32 @@ openapi:
   auth:
 {{ toYaml $openapi.auth | indent 4 }}
 {{- end }}
-{{- /* urlTransform — always emitted: identity + catch-all external-host mappings */ -}}
+{{- /* urlTransform — only emitted when the user actually configured something.
+       The previously auto-generated identity entry was a no-op, and the
+       auto-generated external-host catch-all entries were never matched in
+       practice (.NET swagger specs advertise the host they were fetched from,
+       which is already the internal address). Users who do need to rewrite
+       extra hosts can supply them via networking.krakend.urlTransform.extraHostMapping. */ -}}
 {{- $urlTransform := dig "urlTransform" dict $krakend -}}
-{{- $externalHostsStr := include "helm.krakend.externalHosts" . -}}
-{{- $externalHosts := list -}}
-{{- if $externalHostsStr -}}
-{{- $externalHosts = splitList "\n" $externalHostsStr -}}
-{{- end -}}
-{{- $extra := dig "extraHostMapping" (list) $urlTransform }}
+{{- $extra := dig "extraHostMapping" (list) $urlTransform -}}
+{{- $hasStripPath := hasKey $urlTransform "stripPathPrefix" -}}
+{{- $hasAddPath := hasKey $urlTransform "addPathPrefix" -}}
+{{- $hasExtra := gt (len $extra) 0 -}}
+{{- if or $hasStripPath $hasAddPath $hasExtra }}
 urlTransform:
+{{- if $hasExtra }}
   hostMapping:
-    - from: {{ $internalURL | quote }}
-      to: {{ $internalURL | quote }}
-{{- range $host := $externalHosts }}
-{{- if $host }}
-    - from: {{ printf "http://%s" $host | quote }}
-      to: {{ $internalURL | quote }}
-    - from: {{ printf "https://%s" $host | quote }}
-      to: {{ $internalURL | quote }}
-{{- end }}
-{{- end }}
 {{- range $entry := $extra }}
     - from: {{ $entry.from | quote }}
       to: {{ $entry.to | quote }}
 {{- end }}
-{{- if hasKey $urlTransform "stripPathPrefix" }}
+{{- end }}
+{{- if $hasStripPath }}
   stripPathPrefix: {{ $urlTransform.stripPathPrefix | quote }}
 {{- end }}
-{{- if hasKey $urlTransform "addPathPrefix" }}
+{{- if $hasAddPath }}
   addPathPrefix: {{ $urlTransform.addPathPrefix | quote }}
+{{- end }}
 {{- end }}
 {{- /* defaults passthrough */ -}}
 {{- if hasKey $krakend "defaults" }}

--- a/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
+++ b/charts/mycarrier-helm/templates/krakendAutoConfig.yaml
@@ -4,8 +4,9 @@ KrakenDAutoConfig — one per application that sets networking.krakend.enabled: 
 The operator (gateway.krakend.io/v1alpha1) watches this CR and generates
 KrakenD endpoints from the referenced OpenAPI spec. The spec.openapi.url is
 always built from the application's `.internal` host — never the public
-domain — and urlTransform.hostMapping auto-rewrites any external host the
-OpenAPI `servers:` block may advertise back to the internal URL.
+domain. urlTransform.hostMapping is only emitted when the user supplies
+extraHostMapping (or stripPathPrefix/addPathPrefix); the chart does not
+auto-generate catch-all rewrite entries.
 
 NOTE: KAC rendering currently requires a non-feature environment,
 networking.istio.enabled=true, networking.istio.internalEnabled=true, and

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -72,14 +72,10 @@ tests:
       - equal:
           path: spec.openapi.allowClusterLocal
           value: true
-      - equal:
-          path: spec.urlTransform.hostMapping[0].from
-          value: http://app-routingguide-publicapi.dev.internal
-      - equal:
-          path: spec.urlTransform.hostMapping[0].to
-          value: http://app-routingguide-publicapi.dev.internal
+      - notExists:
+          path: spec.urlTransform
 
-  - it: should include catch-all hostMapping entries for external hosts
+  - it: should not emit urlTransform when no transforms are configured
     set:
       environment.name: dev
       global.appStack: mycarrier
@@ -94,21 +90,8 @@ tests:
       applications.routingguide-publicapi.networking.krakend.enabled: true
       applications.routingguide-publicapi.networking.krakend.gatewayRef.name: mycarrier-public-api
     asserts:
-      - contains:
-          path: spec.urlTransform.hostMapping
-          content:
-            from: http://mycarrier-routingguide-publicapi.dev.mycarrier.dev
-            to: http://mycarrier-routingguide-publicapi.dev.internal
-      - contains:
-          path: spec.urlTransform.hostMapping
-          content:
-            from: https://mycarrier-routingguide-publicapi.dev.mycarrier.dev
-            to: http://mycarrier-routingguide-publicapi.dev.internal
-      - contains:
-          path: spec.urlTransform.hostMapping
-          content:
-            from: http://custom.example.com
-            to: http://mycarrier-routingguide-publicapi.dev.internal
+      - notExists:
+          path: spec.urlTransform
 
   - it: should honor a custom openapi.path
     set:

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -889,12 +889,26 @@
                       "openapi": {
                         "type": "object",
                         "additionalProperties": false,
-                        "description": "OpenAPI spec source. Note: the URL itself is auto-generated from the application's `.internal` address; only the path component is user-configurable.",
+                        "description": "OpenAPI spec source. By default the URL is auto-generated from the application's `.internal` address using `path`. To bypass auto-generation, set `url` (or `configMapRef`) directly; the supplied value is passed through to the CR.",
                         "properties": {
+                          "url": {
+                            "type": "string",
+                            "description": "Explicit OpenAPI spec URL. When set, overrides the auto-generated http://<app>.<metaEnv>.internal<path> URL. Must point to an internal address (.internal or .svc.cluster.local) and must not contain the external domain."
+                          },
                           "path": {
                             "type": "string",
                             "default": "/swagger/v1/swagger.json",
-                            "description": "Path portion appended to http://<app>.<metaEnv>.internal. Defaults to /swagger/v1/swagger.json."
+                            "description": "Path portion appended to http://<app>.<metaEnv>.internal. Ignored when `url` is set. Defaults to /swagger/v1/swagger.json."
+                          },
+                          "configMapRef": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["name", "key"],
+                            "description": "Load the OpenAPI spec from a ConfigMap key instead of fetching a URL.",
+                            "properties": {
+                              "name": { "type": "string" },
+                              "key": { "type": "string" }
+                            }
                           },
                           "format": {
                             "type": "string",
@@ -918,9 +932,22 @@
                         "properties": {
                           "stripPathPrefix": { "type": "string" },
                           "addPathPrefix": { "type": "string" },
+                          "hostMapping": {
+                            "type": "array",
+                            "description": "Direct passthrough of KrakenDAutoConfigSpec.urlTransform.hostMapping. Equivalent to extraHostMapping; provided so users can paste rendered CR values verbatim. Each `to:` value must point to an internal address and must not contain the external domain.",
+                            "items": {
+                              "type": "object",
+                              "required": ["from", "to"],
+                              "additionalProperties": false,
+                              "properties": {
+                                "from": { "type": "string" },
+                                "to": { "type": "string" }
+                              }
+                            }
+                          },
                           "extraHostMapping": {
                             "type": "array",
-                            "description": "Additional host mappings appended AFTER the auto-generated identity + catch-all entries. The `to:` value must not contain the external domain; rendering fails otherwise.",
+                            "description": "Alias for hostMapping retained for backward compatibility. Entries are appended to any `hostMapping` entries. Each `to:` value must not contain the external domain.",
                             "items": {
                               "type": "object",
                               "required": ["from", "to"],

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -279,9 +279,9 @@ applications: {}
 #     #
 #     # Guarantees:
 #     #   - spec.openapi.url is always http://<app>.<metaEnv>.internal/<path>
-#     #   - spec.urlTransform.hostMapping auto-includes catch-all entries that
-#     #     rewrite any external host from the OpenAPI `servers:` block back
-#     #     to the internal URL.
+#     #   - spec.urlTransform.hostMapping is only emitted when the user
+#     #     configures extraHostMapping; auto-generated catch-all entries
+#     #     are intentionally not produced.
 #     krakend:
 #       enabled: false
 #       # name: custom-kac-name            # optional; defaults to <fullName>-autoconfig


### PR DESCRIPTION
This pull request updates the `mycarrier-helm` chart to change how OpenAPI and URL transform host mappings are handled, focusing on increased user control and stricter validation of internal addresses. The chart no longer auto-generates catch-all `hostMapping` entries for external hosts; instead, `hostMapping` is only emitted when explicitly configured by the user. There are also new options for specifying the OpenAPI spec source, and validations have been improved to ensure only internal addresses are referenced. Documentation, schema, and tests are updated accordingly.

**Key changes:**

**1. Host Mapping and URL Transform Behavior**
- The chart no longer auto-generates catch-all `urlTransform.hostMapping` entries for external hosts. Instead, this section is only emitted if the user configures `stripPathPrefix`, `addPathPrefix`, or supplies explicit `hostMapping` or `extraHostMapping` entries. This prevents unintended exposure of internal services and gives users full control. [[1]](diffhunk://#diff-ac3de5fdb70160ed4a1f731823b78745eb92b3e5ffdffb08085c3037f8e7ea4aL1059-R1063) [[2]](diffhunk://#diff-51ef64ebd9e45c04d6b88cde74f7d46c46159051a629e121fcabb65f99b0854cL263-R290) [[3]](diffhunk://#diff-09bebfd8b37e6b0133c0e756878288bdd378b5c930115dfcb6151a25ea70935aL7-R9) [[4]](diffhunk://#diff-e91ac30dddf1bba98f972dcf93d61f8d3a2881d25bdde52f1b63fe8965a8ca0cL282-R284)

**2. OpenAPI Spec Source Enhancements**
- Users can now explicitly set `openapi.url` or load the spec from a ConfigMap via `openapi.configMapRef`, bypassing the default auto-generated internal URL. The schema and template logic are updated to support these options. [[1]](diffhunk://#diff-03099590ba9350d564fc5e6114e9d0621b657dd547922030f40587eb924b17fcL892-R911) [[2]](diffhunk://#diff-51ef64ebd9e45c04d6b88cde74f7d46c46159051a629e121fcabb65f99b0854cL247-R256)

**3. Internal Address Validation**
- Templating logic now strictly validates that all `to:` values in host mappings and the OpenAPI URL reference only internal addresses (ending in `.internal` or `.svc.cluster.local`) and do not contain the external domain. This validation is centralized and improved for clarity and safety. [[1]](diffhunk://#diff-51ef64ebd9e45c04d6b88cde74f7d46c46159051a629e121fcabb65f99b0854cL194-R195) [[2]](diffhunk://#diff-51ef64ebd9e45c04d6b88cde74f7d46c46159051a629e121fcabb65f99b0854cL213-R204)

**4. Documentation and Schema Updates**
- The README, values schema, and values.yaml examples are updated to reflect the new behavior: host mappings are not auto-generated, and new OpenAPI source options are documented. Descriptions clarify the new expectations and validation rules. [[1]](diffhunk://#diff-ac3de5fdb70160ed4a1f731823b78745eb92b3e5ffdffb08085c3037f8e7ea4aL1126-R1126) [[2]](diffhunk://#diff-03099590ba9350d564fc5e6114e9d0621b657dd547922030f40587eb924b17fcR935-R950) [[3]](diffhunk://#diff-e91ac30dddf1bba98f972dcf93d61f8d3a2881d25bdde52f1b63fe8965a8ca0cL282-R284)

**5. Test Adjustments**
- Tests are updated to assert that `urlTransform` is not emitted when not explicitly configured and that auto-generated catch-all mappings are no longer present. [[1]](diffhunk://#diff-376ac8b592f8573ffbbd82ed48636312500d8a55ec1478b129106d0f3dcc6e54L75-R78) [[2]](diffhunk://#diff-376ac8b592f8573ffbbd82ed48636312500d8a55ec1478b129106d0f3dcc6e54L97-R94)

**Other:**
- Chart version bumped from `3.1.0` to `3.1.1`.