### PR TITLE
Refactor virtual service configuration to enable OffloadVS

### DIFF
--- a/charts/mycarrier-helm/templates/virtualService.yaml
+++ b/charts/mycarrier-helm/templates/virtualService.yaml
@@ -34,7 +34,7 @@ spec:
   {{ include "helm.specs.virtualservice" $appContext | indent 2 | trim }}
 {{- end }}
 {{- $offloadVSEnabled := dig "networking" "istio" "offloadVSEnabled" true $appValues }}
-{{- if and (hasPrefix "feature" $.Values.environment.name) $offloadVSEnabled (not (dig "networking" "krakend" "enabled" false $appValues)) (not ($.Values.isEnvironmentDeploy | default false)) }}
+{{- if and $istioEnabled (not $appIstioDisabled) (not $serviceIstioDisabled) (hasPrefix "feature" $.Values.environment.name) $offloadVSEnabled (not (dig "networking" "krakend" "enabled" false $appValues)) (not ($.Values.isEnvironmentDeploy | default false)) }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/charts/mycarrier-helm/templates/virtualService.yaml
+++ b/charts/mycarrier-helm/templates/virtualService.yaml
@@ -32,8 +32,9 @@ metadata:
     {{ include "helm.annotations.virtualservice" $appContext | indent 4 | trim }}
 spec:
   {{ include "helm.specs.virtualservice" $appContext | indent 2 | trim }}
+{{- end }}
 {{- $offloadVSEnabled := dig "networking" "istio" "offloadVSEnabled" true $appValues }}
-{{- if and (hasPrefix "feature" $.Values.environment.name) $offloadVSEnabled (not $offloadOperatorEnabled) }}
+{{- if and (hasPrefix "feature" $.Values.environment.name) $offloadVSEnabled (not (dig "networking" "krakend" "enabled" false $appValues)) (not ($.Values.isEnvironmentDeploy | default false)) }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -45,29 +46,15 @@ metadata:
   annotations:
     {{ include "helm.annotations.virtualservice" $appContext | indent 4 | trim }}
 spec:
-  {{- $baseFullName := include "helm.basename" $appContext }}
-  {{- $metaNamespace := include "helm.metaEnvironment" $ }}
   exportTo:
   - .
-  - {{ $metaNamespace }}
   - istio-system
   hosts:
   - {{ $fullName }}
   - {{ $fullName }}.{{ $namespace }}.svc
   - {{ $fullName }}.{{ $namespace }}.svc.cluster.local
-  - {{ $baseFullName }}
-  {{- if $internalEnabled }}
-  - {{ $baseFullName }}.{{ $metaNamespace }}.internal
-  {{- end }}
-  - {{ $baseFullName }}.{{ $metaNamespace }}.svc
-  - {{ $baseFullName }}.{{ $metaNamespace }}.svc.cluster.local
-  {{- if and $appValues.staticHostname (not ($.Values.isEnvironmentDeploy | default false)) }}
-  - {{ $appValues.staticHostname | trimSuffix "."}}.{{ $domain }}
-  {{- else }}
-  - {{ (list ($.Values.global.appStack) ($appName)) | join "-" | lower | trunc 63 | trimSuffix "-" }}.{{ $domainPrefix }}.{{ $domain }}
-  {{- end }}
+  - {{ $fullName }}.{{ $domainPrefix }}.{{ $domain }}
   {{- /* Include additional custom hosts from networking.istio.hosts */ -}}
-  {{- $istioConfig := dig "networking" "istio" dict $appValues -}}
   {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts -}}
   {{- range $istioConfig.hosts }}
   - {{ . }}
@@ -83,24 +70,5 @@ spec:
           host: "{{ $fullName }}.{{ $namespace }}.svc.cluster.local"
           port:
             number: {{ default 8080 (dig "ports" "http" nil $appValues) }}
-    match:
-      - headers:
-          environment:
-            exact: {{ $.Values.environment.name }}
-  - name: {{ $baseFullName }}-dev-fallback
-    match:
-      - withoutHeaders:
-          environment: {}
-      - headers:
-          environment:
-            exact: {{ $metaNamespace }}
-    route:
-      - destination:
-          host: "{{ $baseFullName }}.{{ $metaNamespace }}.svc.cluster.local"
-          port:
-            number: {{ default 8080 (dig "ports" "http" nil $appValues) }}
-    headers:
-{{ include "helm.istioIngress.responseHeaders" $ | nindent 6 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/mycarrier-helm/tests/internal_enabled_flag_test.yaml
+++ b/charts/mycarrier-helm/tests/internal_enabled_flag_test.yaml
@@ -197,7 +197,7 @@ tests:
           path: spec.hosts
           content: app-test-app.dev.internal
 
-  - it: should include internal host in offload VS when internalEnabled is true (default)
+  - it: should not include dev internal host in offload VS (no dev refs in offload)
     template: virtualService.yaml
     set:
       environment.name: feature-test-branch
@@ -213,6 +213,6 @@ tests:
     asserts:
       - isKind:
           of: VirtualService
-      - contains:
+      - notContains:
           path: spec.hosts
           content: app-test-app.dev.internal

--- a/charts/mycarrier-helm/tests/offload_operator_test.yaml
+++ b/charts/mycarrier-helm/tests/offload_operator_test.yaml
@@ -43,7 +43,7 @@ tests:
       - isKind:
           of: VirtualService
 
-  - it: should NOT render offload VS in feature env when offloadOperatorEnabled is true
+  - it: should render offload VS in feature env even when offloadOperatorEnabled is true (no longer gated by it)
     template: virtualService.yaml
     set:
       environment.name: "feature13"
@@ -58,7 +58,12 @@ tests:
       applications.routetester.networking.istio.offloadOperatorEnabled: true
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - isKind:
+          of: VirtualService
+      - equal:
+          path: metadata.name
+          value: devopstest-routetester-feature13-offload
 
   #
   # OffloadBase (dev only)

--- a/charts/mycarrier-helm/tests/virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/virtualservice_test.yaml
@@ -124,27 +124,8 @@ tests:
           value: app-test-app-api-feature-test
         documentIndex: 0
       - equal:
-          path: spec.http[0].match[0].headers.environment.exact
-          value: feature-test
-        documentIndex: 1
-      - equal:
-          path: spec.http[1].match[0].withoutHeaders.environment
-          value: {}
-        documentIndex: 1
-      - equal:
-          path: spec.http[1].match[1].headers.environment.exact
-          value: dev
-        documentIndex: 1
-      - equal:
-          path: spec.http[1].route[0].destination.host
-          value: app-test-app-api.dev.svc.cluster.local
-        documentIndex: 1
-      - notExists:
-          path: spec.http[1].headers.request
-        documentIndex: 1
-      - equal:
-          path: spec.http[1].headers.response.set["Strict-Transport-Security"]
-          value: "max-age=7884000; includeSubDomains; preload"
+          path: spec.http[0].route[0].destination.host
+          value: app-test-app-api-feature-test.feature-test.svc.cluster.local
         documentIndex: 1
       - equal:
           path: spec.hosts[1]
@@ -168,23 +149,7 @@ tests:
         documentIndex: 1
       - equal:
           path: spec.hosts[3]
-          value: app-test-app-api
-        documentIndex: 1
-      - equal:
-          path: spec.hosts[4]
-          value: app-test-app-api.dev.internal
-        documentIndex: 1
-      - equal:
-          path: spec.hosts[5]
-          value: app-test-app-api.dev.svc
-        documentIndex: 1
-      - equal:
-          path: spec.hosts[6]
-          value: app-test-app-api.dev.svc.cluster.local
-        documentIndex: 1
-      - equal:
-          path: spec.hosts[7]
-          value: app-test-app-api.dev.mycarrier.dev
+          value: app-test-app-api-feature-test.dev.mycarrier.dev
         documentIndex: 1
 
   - it: should include staticHostname in feature environment when isEnvironmentDeploy is true
@@ -200,6 +165,9 @@ tests:
       applications.test-app-api.ports.http: 8080
       applications.test-app-api.networking.istio.offloadOperatorEnabled: false
     asserts:
+      # Only main VS renders (offload VS suppressed when isEnvironmentDeploy=true)
+      - hasDocuments:
+          count: 1
       # Primary VS: staticHostname included alongside feature hostname
       - contains:
           path: spec.hosts
@@ -209,15 +177,6 @@ tests:
           path: spec.hosts
           content: app-test-app-api-feature-test.dev.mycarrier.dev
         documentIndex: 0
-      # Offload VS: isEnvironmentDeploy=true so staticHostname absent, default host present
-      - notContains:
-          path: spec.hosts
-          content: api.custom.domain.mycarrier.dev
-        documentIndex: 1
-      - contains:
-          path: spec.hosts
-          content: app-test-app-api.dev.mycarrier.dev
-        documentIndex: 1
 
   - it: should not include staticHostname in feature environment when isEnvironmentDeploy is false
     set:
@@ -241,14 +200,18 @@ tests:
           path: spec.hosts
           content: api.custom.domain.mycarrier.dev
         documentIndex: 0
-      # Offload VS: isEnvironmentDeploy=false so staticHostname present, default host absent
-      - contains:
+      # Offload VS: no dev refs and no staticHostname, only feature-specific hosts
+      - notContains:
           path: spec.hosts
           content: api.custom.domain.mycarrier.dev
         documentIndex: 1
       - notContains:
           path: spec.hosts
           content: app-test-app-api.dev.mycarrier.dev
+        documentIndex: 1
+      - contains:
+          path: spec.hosts
+          content: app-test-app-api-feature-test.dev.mycarrier.dev
         documentIndex: 1
 
   - it: should not render virtual service when istio is explicitly disabled
@@ -646,7 +609,7 @@ tests:
           value: teststack-test-app-feature-test-branch-offload
         documentIndex: 1
 
-  - it: should use staticHostname in offload VS hosts when isEnvironmentDeploy is false
+  - it: should not include staticHostname or dev hostname in offload VS hosts
     set:
       global.appStack: teststack
       global.language: csharp
@@ -660,7 +623,7 @@ tests:
       applications.test-app.networking.istio.enabled: true
       applications.test-app.networking.istio.offloadOperatorEnabled: false
     asserts:
-      - contains:
+      - notContains:
           path: spec.hosts
           content: api.custom.domain.mycarrier.dev
         documentIndex: 1
@@ -668,15 +631,17 @@ tests:
           path: spec.hosts
           content: teststack-test-app.dev.mycarrier.dev
         documentIndex: 1
+      - contains:
+          path: spec.hosts
+          content: teststack-test-app-feature-test-branch.dev.mycarrier.dev
+        documentIndex: 1
 
-  - it: should use default hostname in offload VS hosts when isEnvironmentDeploy is true
+  - it: should include feature hostname in offload VS when krakend is disabled
     set:
       global.appStack: teststack
       global.language: csharp
       environment.name: "feature-test-branch"
-      isEnvironmentDeploy: true
       applications.test-app.deploymentType: deployment
-      applications.test-app.staticHostname: "api.custom.domain"
       applications.test-app.image.registry: "test.io"
       applications.test-app.image.repository: "test/app"
       applications.test-app.image.tag: "1.0.0"
@@ -685,9 +650,45 @@ tests:
     asserts:
       - contains:
           path: spec.hosts
-          content: teststack-test-app.dev.mycarrier.dev
+          content: teststack-test-app-feature-test-branch.dev.mycarrier.dev
         documentIndex: 1
-      - notContains:
+
+  - it: should NOT render offload VS when krakend.enabled is true
+    set:
+      global.appStack: teststack
+      global.language: csharp
+      environment.name: "feature-test-branch"
+      applications.test-app.deploymentType: deployment
+      applications.test-app.image.registry: "test.io"
+      applications.test-app.image.repository: "test/app"
+      applications.test-app.image.tag: "1.0.0"
+      applications.test-app.networking.istio.enabled: true
+      applications.test-app.networking.istio.offloadOperatorEnabled: false
+      applications.test-app.networking.krakend.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: teststack-test-app-feature-test-branch
+
+  - it: should render offload VS even when offloadOperator is enabled (no longer gated by it)
+    set:
+      global.appStack: teststack
+      global.language: csharp
+      environment.name: "feature-test-branch"
+      applications.test-app.deploymentType: deployment
+      applications.test-app.image.registry: "test.io"
+      applications.test-app.image.repository: "test/app"
+      applications.test-app.image.tag: "1.0.0"
+      applications.test-app.networking.istio.enabled: true
+      applications.test-app.networking.istio.offloadOperatorEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: teststack-test-app-feature-test-branch-offload
+      - contains:
           path: spec.hosts
-          content: api.custom.domain.mycarrier.dev
-        documentIndex: 1
+          content: teststack-test-app-feature-test-branch.dev.mycarrier.dev

--- a/charts/mycarrier-helm/tests/withoutheaders_dev_only_test.yaml
+++ b/charts/mycarrier-helm/tests/withoutheaders_dev_only_test.yaml
@@ -185,7 +185,7 @@ tests:
   # ==========================================
   # FEATURE ENVIRONMENT - withoutHeaders only in offload VS targeting dev
   # ==========================================
-  - it: should include withoutHeaders in feature environment offload virtualservice dev fallback
+  - it: should NOT include withoutHeaders in feature environment offload virtualservice (no dev fallback)
     set:
       global:
         appStack: test-stack
@@ -213,9 +213,9 @@ tests:
       - equal:
           path: metadata.name
           value: test-stack-test-app-feature-abc-offload
-      # Feature offload VS should have withoutHeaders in dev-fallback route (http[2] is dev-fallback in offload VS)
-      - exists:
-          path: spec.http[1].match[0].withoutHeaders.environment
+      # Offload VS no longer has dev-fallback route, so no withoutHeaders
+      - notExists:
+          path: spec.http[1]
 
   - it: should NOT include withoutHeaders in feature environment primary virtualservice
     set:

--- a/charts/mycarrier-helm/tests/withoutheaders_dev_only_test.yaml
+++ b/charts/mycarrier-helm/tests/withoutheaders_dev_only_test.yaml
@@ -183,7 +183,7 @@ tests:
           path: spec.http[2].match[0].withoutHeaders
 
   # ==========================================
-  # FEATURE ENVIRONMENT - withoutHeaders only in offload VS targeting dev
+  # FEATURE ENVIRONMENT - offload VS has no dev-fallback route, so no withoutHeaders
   # ==========================================
   - it: should NOT include withoutHeaders in feature environment offload virtualservice (no dev fallback)
     set:

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -715,7 +715,7 @@
                           },
                           "offloadOperatorEnabled": {
                             "type": "boolean",
-                            "description": "Enable offload-operator managed routing. When true, the standard VirtualService and offload VS are suppressed, and OffloadBase/OffloadRoute CRDs are rendered instead. Defaults to true when metaEnvironment is dev, false otherwise. Set explicitly to override.",
+                            "description": "Enable offload-operator managed routing. When true, the standard VirtualService is suppressed and OffloadBase/OffloadRoute CRDs are rendered instead. Does NOT affect the offload VirtualService — that is gated by `offloadVSEnabled`, `networking.krakend.enabled`, and `isEnvironmentDeploy`. Defaults to true when metaEnvironment is dev, false otherwise. Set explicitly to override.",
                             "default": true
                           },
                           "offloadCreationPolicy": {


### PR DESCRIPTION
# Feature-specific hostnames in offload VS for non-krakend apps

## Summary

When an app deployed to a feature environment has `networking.krakend.enabled = false` (i.e., it relies on direct public URLs rather than the KrakenD gateway), the offload `VirtualService` now exposes the feature-specific hostname `{$fullName}.{$domainPrefix}.{$domain}` (e.g. `app-myapp-feature20.dev.mycarrier.dev`) and routes it directly to the feature pod — with no references to the dev instance.

## Problem

The offload VS rendered alongside the main VS for feature environments, but only on the dev hostname (`{appstack}-{app}.dev.mycarrier.dev`) with header-based routing and a dev-fallback route. There was no public hostname tied specifically to the feature deployment, so apps that don't sit behind KrakenD had no direct URL into a feature env.

In addition, the offload VS was gated on `not $offloadOperatorEnabled`, so when the offload operator was enabled (the dev-metaenv default) the offload VS was suppressed entirely and the feature env had no public hostname at all.

## Changes

### `templates/virtualService.yaml`

**Render condition** — the offload VS now renders when **all** of the following are true:

- `environment.name` starts with `feature`
- `networking.istio.offloadVSEnabled` is `true` (default)
- `networking.krakend.enabled` is `false` (default)
- `isEnvironmentDeploy` is `false` (default)

`$domainPrefix` resolves to `api` in prod and to `$metaenv` (e.g. `dev`) elsewhere; `$domain` resolves to `mycarriertms.com` in prod and `mycarrier.dev` elsewhere (and respects `environment.domainOverride`).

`offloadOperatorEnabled` no longer affects the offload VS — the block was lifted out of the `if $renderVirtualService` wrapper.

**Body** — stripped of every dev-instance reference:

| Removed | Why |
| --- | --- |
| `$baseFullName` short / `.svc` / `.svc.cluster.local` hosts | Point at dev pod |
| `$baseFullName.{metaenv}.internal` | Dev internal ServiceEntry |
| `staticHostname` / `{appstack}-{app}.{domainPrefix}.{domain}` if-else block | Resolves to dev public host |
| `{metaenv}` entry in `exportTo` | Dev namespace export |
| `{baseFullName}-dev-fallback` http route + response-header block | Routed to dev pod |

**Added:** `{{ $fullName }}.{{ $domainPrefix }}.{{ $domain }}` to `spec.hosts` — the feature-specific public hostname (e.g. `app-myapp-feature20.dev.mycarrier.dev`).

The offload VS now has only feature-namespace addresses + the feature public host, and a single route to `{$fullName}.{$namespace}.svc.cluster.local`.

## Net effect (feature environment with `staticHostname` set)

| `isEnvironmentDeploy` | Main VS hosts | Offload VS |
| --- | --- | --- |
| `false` (default) | `$fullName`, `$fullName.$domainPrefix.$domain` | renders with `$fullName.$domainPrefix.$domain` |
| `true` | `$fullName`, `$fullName.$domainPrefix.$domain`, `staticHostname.domain` | not rendered |

`isEnvironmentDeploy=true` means a tagged release deployed under the static external URL, so the feature-branch offload VS is irrelevant and is suppressed.

## Net effect (feature environment, all flags)

| `krakend.enabled` | `offloadVSEnabled` | `isEnvironmentDeploy` | `offloadOperatorEnabled` | Offload VS |
| --- | --- | --- | --- | --- |
| `false` (default) | `true` (default) | `false` (default) | any | renders |
| `false` | `true` | `false` | any | renders |
| `true` | any | any | any | not rendered |
| any | `false` | any | any | not rendered |
| any | any | `true` | any | not rendered |

Note: `offloadOperatorEnabled` no longer affects the offload VS — `OffloadBase` and `OffloadRoute` CRDs are emitted independently by the offload operator templates and coexist with the offload VS.

### Tests

Updated tests across four suites to match the new offload VS shape:

- `tests/virtualservice_test.yaml` — feature-branch hosts assertions trimmed to the four feature-only hosts; `staticHostname` and dev-hostname offload assertions replaced with `notContains`; `isEnvironmentDeploy: true` test now asserts `count: 1` (no offload VS); added two new tests: offload VS suppressed when `krakend.enabled = true`, and offload VS rendered even when `offloadOperatorEnabled = true`.
- `tests/offload_operator_test.yaml` — the prior "should NOT render offload VS when offloadOperatorEnabled is true" test was inverted: it now asserts the offload VS *is* rendered.
- `tests/internal_enabled_flag_test.yaml` — flipped the "should include internal host" assertion to `notContains` since dev internal hosts are no longer in the offload VS.
- `tests/withoutheaders_dev_only_test.yaml` — flipped the dev-fallback `withoutHeaders` assertion to `notExists` since the dev-fallback route is gone.

All 485 unit tests pass.