### PR TITLE
fix(krakend): soft-skip KrakenDAutoConfig in feature envs

### DIFF
--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -21,13 +21,15 @@ that points at an internal host that was never created.
 
 Prerequisites (all must hold):
   - networking.krakend.enabled == true
-  - not a feature environment
+  - not a feature environment (feature envs return "false" — render is silently
+    skipped, no hard failure)
   - networking.istio.enabled == true
   - istioDisabled != true (top-level application flag)
   - service.istioDisabled != true
   - networking.istio.internalEnabled == true
 
-Any violation fails the render with a clear, targeted error.
+Feature environments silently return "false" (skip). All other violations
+fail the render with a clear, targeted error.
 
 Usage:
   {{- if eq (include "helm.krakend.enabled" $appContext) "true" }}
@@ -45,7 +47,7 @@ false
 {{- $serviceIstioDisabled := dig "service" "istioDisabled" false $app -}}
 {{- $internalEnabled := dig "networking" "istio" "internalEnabled" true $app -}}
 {{- if hasPrefix "feature" $envName -}}
-{{- fail (printf "networking.krakend.enabled=true is not supported in feature environments (got environment=%q). Each KrakenDAutoConfig registers endpoints on the shared KrakenDGateway, so per-feature-env variants would collide with the dev-env KrakenDAutoConfig for the same application. New public API endpoints must be developed and released directly to dev." $envName) -}}
+false
 {{- else if not $istioEnabled -}}
 {{- fail (printf "networking.krakend.enabled=true requires networking.istio.enabled=true. The KrakenDAutoConfig spec.openapi.url relies on the application's `.internal` ServiceEntry, which is not rendered when Istio is disabled.") -}}
 {{- else if $appIstioDisabled -}}

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -147,7 +147,7 @@ tests:
       - failedTemplate:
           errorMessage: 'application "api": networking.krakend.periodic.interval is required when trigger=Periodic'
 
-  - it: should fail in feature environments
+  - it: should silently skip rendering in feature environments
     set:
       environment.name: feature-x
       applications.api.image.registry: r
@@ -159,8 +159,8 @@ tests:
       applications.api.networking.krakend.enabled: true
       applications.api.networking.krakend.gatewayRef.name: gw
     asserts:
-      - failedTemplate:
-          errorPattern: 'not supported in feature environments'
+      - hasDocuments:
+          count: 0
 
   - it: should fail when internalEnabled=false
     set:


### PR DESCRIPTION
## Summary
- `helm.krakend.enabled` helper in `charts/mycarrier-helm/templates/_helpers_krakend.tpl` no longer hard-fails the render when `environment.name` starts with `feature`. Instead returns `"false"` so `KrakenDAutoConfig` is silently skipped in feature envs.
- Matches existing soft-skip patterns used by KEDA (`_helpers.tpl`) and offload VirtualService (`templates/virtualService.yaml`).

## Why
Any application with `networking.krakend.enabled=true` in shared base values aborted the entire feature-env release. Example: MC.Address `public-api` offload to `feature27` failed with `Error: execution error at (mycarrier-helm/templates/krakendAutoConfig.yaml:20:11): networking.krakend.enabled=true is not supported in feature environments`. Intent — keep `KrakenDAutoConfig` dev-only to avoid `KrakenDGateway` endpoint collisions — is preserved: KAC simply does not render in feature envs.

## Test plan
- [ ] `helm lint charts/mycarrier-helm` passes
- [ ] `helm template` renders for a chart consumer with `networking.krakend.enabled=true` and `environment.name=feature27` without error and without emitting a `KrakenDAutoConfig`
- [ ] Re-run MC.Address offload to feature27 — succeeds
- [ ] Existing dev/preprod/prod renders unchanged (KAC still emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)