### PR TITLE
feat: implement enableV1 option for test triggers to bundle definitions in a single curl call

### DIFF
--- a/charts/mycarrier-helm/TestTriggersGuide.md
+++ b/charts/mycarrier-helm/TestTriggersGuide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Test triggers are configured in the Helm values files (e.g., `values.dev.yaml`, `values.prod.yaml`) and are processed by the Helm templates to create Kubernetes jobs that execute test triggers. Each test definition configures a curl call to the test engine API. This means that each test trigger can have an array of test definitions, and each application can have its own configuration of test triggers with their respective test definitions.
+Test triggers are configured in the Helm values files (e.g., `values.dev.yaml`, `values.prod.yaml`) and are processed by the Helm templates to create Kubernetes jobs that execute test triggers. For each application, all of its test definitions are bundled into a single curl call to the test engine API with a `{"Tests": [...]}` payload. Each application can have its own configuration of test triggers with their respective test definitions.
 
 ### ArgoCD Integration
 
@@ -35,6 +35,7 @@ applications:
         limits:
           memory: "<memory-limit>"
           cpu: "<cpu-limit>"
+      enableV1: <true|false>         # Optional — see enableV1 section below
       testdefinitions:
         - containerImage: <image-name>
           containerTag: <tag>
@@ -79,7 +80,8 @@ applications:
 | `backoffLimit` | Number of retries for the test job in case of failure | No | `0` | `0` |
 | `resources` | Resource requests and limits for the test job pod | No | See below* | See example below |
 | `ttlSecondsAfterFinished` | Time in seconds to keep the job after it finishes | No | `"3600"` | `"3600"` |
-| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference. **Optional** — when omitted, the chart uses `global.testengineWebhookUrl` injected by the CI/CD render step, which auto-selects the dev or prod testengine endpoint based on the Argo workflow namespace. | No | `global.testengineWebhookUrl` (injected by render); hard fallback to `vault:DevOps/data/testengine/api#url` when absent (e.g. local render) | `"vault:Secrets/data/path/to/secret#url"` |
+| `enableV1` | When `true`, all test definitions are bundled into a single POST to `api/v1` with a `{"Tests":[...]}` payload. When `false` (default), each test definition sends a separate POST to the legacy `api` endpoint. | No | `false` | `true` |
+| `webhook_url` | URL of the test engine webhook, can be a direct value or a vault reference. **Optional** — when omitted, the chart selects the default based on `enableV1`: `vault:DevOps/data/testengine/api/v1#url` when `enableV1: true`, `vault:DevOps/data/testengine/api#url` otherwise. `global.testengineWebhookUrl` (injected by the CI/CD render step) overrides both defaults. | No | `vault:DevOps/data/testengine/api/v1#url` (enableV1) / `vault:DevOps/data/testengine/api#url` (legacy) | `"vault:Secrets/data/path/to/secret#url"` |
 
 *Default resource values:
 ```yaml
@@ -286,7 +288,7 @@ applications:
           name: internalapitests
           secretId: "vault:Secrets/data/auth#secretid"
 ```
-Explanation: This configuration will create test jobs for both the `api` and `internal-api` applications. The `api` application will have two separate test jobs, while the `internal-api` application will have one. The `api` test jobs have custom resource requirements and the first test definition specifies a custom service address.
+Explanation: This configuration creates one test trigger Job per application: one Job for `api` and one Job for `internal-api`. Each Job sends a single curl POST to the test engine API whose payload bundles all of that application's test definitions in a `Tests` array — so the `api` Job's payload contains two test entries and the `internal-api` Job's payload contains one. The `api` Job has custom resource requirements and the first test definition specifies a custom service address.
 
 ## Usage Notes
 
@@ -294,7 +296,7 @@ Explanation: This configuration will create test jobs for both the `api` and `in
 
 2. **Test Filters**: The `filters` array allows you to specify which tests to run. If no filters are provided (empty array), all tests in the container will be executed.
 
-3. **Multiple Test Definitions**: You can define multiple test definitions under a single `testtrigger` configuration, each with its own container image, tag, and filters.
+3. **Multiple Test Definitions**: You can define multiple test definitions under a single `testtrigger` configuration, each with its own container image, tag, and filters. All test definitions for one application are bundled into a single curl POST to the test engine API; the request body is `{"Tests": [...]}` containing each definition as an entry.
 
 4. **Application-Specific Tests**: Each application in your deployment can have its own `testtrigger` configuration, allowing for application-specific tests.
 

--- a/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
+++ b/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
@@ -23,7 +23,8 @@
 {{- end }}
 {{- end }}
 {{- $imageTag :=  .application.image.tag }}
-{{- $defaultWebhookUrl := $.Values.global.testengineWebhookUrl | default "vault:DevOps/data/testengine/api#url" }}
+{{- $enableV1 := dig "testtrigger" "enableV1" false .application }}
+{{- $defaultWebhookUrl := $.Values.global.testengineWebhookUrl | default (ternary "vault:DevOps/data/testengine/api/v1#url" "vault:DevOps/data/testengine/api#url" $enableV1) }}
 {{- if dig "testtrigger" false .application }}
 ttlSecondsAfterFinished: {{ dig "testtrigger" "ttlSecondsAfterFinished" 3600 .application }}
 activeDeadlineSeconds: {{ dig "testtrigger" "activeDeadlineSeconds" 300 .application }}
@@ -40,7 +41,7 @@ template:
       - name: {{ dig "testtrigger" "imagePullSecret" $imagePullSecret .application | quote }}
     restartPolicy: {{ dig "testtrigger" "restartPolicy" $restartPolicy .application | quote  }}
     containers:
-      - image: "alpine/curl:latest"
+      - image: "alpine/curl:8.17.0"
         imagePullPolicy: {{ dig "testtrigger" "imagePullPolicy" "IfNotPresent" .application | quote }}
         name: testtrigger
         env:
@@ -63,6 +64,39 @@ template:
           - /bin/sh
           - -c
           - |
+          {{- if $enableV1 }}
+          {{- $tests := list }}
+          {{- range dig "testtrigger" "testdefinitions" list .application }}
+          {{- $serviceAddress := .serviceAddress | default (printf "http://%s.%s.svc.cluster.local:%v" $fullName $namespace $httpPort) }}
+          {{- $defaultTolerations := list (dict "key" "kubernetes.azure.com/scalesetpriority" "operator" "Equal" "value" "spot" "effect" "NoSchedule") }}
+          {{- $tolerations := $defaultTolerations }}
+          {{- if hasKey . "tolerations" }}
+            {{- $tolerations = .tolerations }}
+          {{- end }}
+          {{- $nodeAffinity := .nodeAffinity | default list }}
+          {{- $useDefaultNodeAffinity := "false" }}
+          {{- if hasKey . "useDefaultNodeAffinity" }}
+            {{- $useDefaultNodeAffinity = printf "%v" .useDefaultNodeAffinity }}
+          {{- end }}
+          {{- $legacyMode := "false" }}
+          {{- if hasKey . "legacyMode" }}
+            {{- $legacyMode = printf "%v" .legacyMode }}
+          {{- end }}
+          {{- $spreadAcrossNodes := "true" }}
+          {{- if hasKey . "spreadAcrossNodes" }}
+            {{- $spreadAcrossNodes = printf "%v" .spreadAcrossNodes }}
+          {{- end }}
+          {{- $defaultPodResources := dict "limits" (dict "cpu" "2000m" "memory" "4Gi") "requests" (dict "cpu" "250m" "memory" "0.5Gi") }}
+          {{- $podResources := .podResources | default $defaultPodResources }}
+          {{- $testEnv := dict "EnvironmentName" $namespace "ReleaseId" $imageTag "SecretId" (.secretId | default "") "ServiceAddress" $serviceAddress "ReleaseDefinitionName" (.releaseDefinitionName | default $baseName) "BranchName" $gitBranch "AdditionalEnvVars" (.additionalEnvVars | default "") "CorrelationId" $correlationId "LegacyMode" $legacyMode }}
+          {{- $test := dict "IsMonolith" false "TestName" .name "StackName" $stackname "ContainerImage" (.containerImage | default "") "ContainerTag" (.containerTag | default "") "TestFilters" .filters "Tolerations" $tolerations "NodeAffinity" $nodeAffinity "UseDefaultNodeAffinity" $useDefaultNodeAffinity "SpreadAcrossNodes" $spreadAcrossNodes "PodResources" $podResources "TestEnvironmentVariables" $testEnv }}
+          {{- $tests = append $tests $test }}
+          {{- end }}
+            curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: $TESTENGINE_APIKEY" \
+            -d '{{ dict "Tests" $tests | toPrettyJson | indent 12 | trimPrefix "            " }}' "$TESTENGINEHOOK_URL"
+          {{- else }}
           {{- range dig "testtrigger" "testdefinitions" list .application }}
           {{- $serviceAddress := .serviceAddress | default (printf "http://%s.%s.svc.cluster.local:%v" $fullName $namespace $httpPort) }}
           {{- $defaultTolerations := list (dict "key" "kubernetes.azure.com/scalesetpriority" "operator" "Equal" "value" "spot" "effect" "NoSchedule") }}
@@ -112,6 +146,7 @@ template:
                   "LegacyMode": "{{ $legacyMode }}"
                 }
               }' "$TESTENGINEHOOK_URL";
+          {{- end }}
           {{- end }}
         {{ include "helm.containerSecurityContext" . | indent 8 | trim }}
 {{- end }}

--- a/charts/mycarrier-helm/tests/triggertests_test.yaml
+++ b/charts/mycarrier-helm/tests/triggertests_test.yaml
@@ -146,8 +146,118 @@ tests:
       - exists:
           path: spec
 
-  # Edge case tests for testdefinitions
-  - it: should handle multiple test definitions correctly
+  # enableV1 / legacy mode tests
+  - it: should bundle all test definitions into a single curl when enableV1 is true
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            enableV1: true
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=api"
+              - name: "uitests"
+                containerImage: "cypress/included"
+                containerTag: "12.8.1"
+                secretId: "vault:Secret/data/ui#SecretId"
+                filters:
+                  - "TestCategory=ui"
+                  - "TestPriority=high"
+              - name: "performancetests"
+                containerImage: "k6/operator"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/performance#SecretId"
+                filters:
+                  - "TestCategory=performance"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"Tests":\s*\['
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"apitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"uitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"performancetests"'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)curl -X POST.*curl -X POST'
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api/v1#url"
+
+  - it: should emit a separate curl per test definition when enableV1 is false
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            enableV1: false
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=api"
+              - name: "uitests"
+                containerImage: "cypress/included"
+                containerTag: "12.8.1"
+                secretId: "vault:Secret/data/ui#SecretId"
+                filters:
+                  - "TestCategory=ui"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"Tests":\['
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName": "apitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName": "uitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)curl -X POST.*curl -X POST'
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api#url"
+
+  - it: should default to legacy mode when enableV1 is omitted
     set:
       fullnameOverride: app
       namespace: dev-app
@@ -175,6 +285,51 @@ tests:
                 secretId: "vault:Secret/data/ui#SecretId"
                 filters:
                   - "TestCategory=ui"
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"Tests":\['
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)curl -X POST.*curl -X POST'
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "vault:DevOps/data/testengine/api#url"
+
+  # Edge case tests for testdefinitions
+  - it: should handle multiple test definitions correctly
+    set:
+      fullnameOverride: app
+      namespace: dev-app
+      metaEnvironment: dev
+      applications:
+        app1:
+          version: 1.0.0
+          enabled: true
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/app1"
+            tag: "1.0.0"
+          testtrigger:
+            ttlSecondsAfterFinished: "300"
+            enableV1: true
+            testdefinitions:
+              - name: "apitests"
+                containerImage: "alpine/curl"
+                containerTag: "latest"
+                secretId: "vault:Secret/data/secret#SecretId"
+                filters:
+                  - "TestCategory=api"
+              - name: "uitests"
+                containerImage: "cypress/included"
+                containerTag: "12.8.1"
+                secretId: "vault:Secret/data/ui#SecretId"
+                filters:
+                  - "TestCategory=ui"
                   - "TestPriority=high"
               - name: "performancetests"
                 containerImage: "k6/operator"
@@ -189,6 +344,21 @@ tests:
           count: 1
       - exists:
           path: spec
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"Tests":\s*\['
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"apitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"uitests"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"TestName":\s*"performancetests"'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)curl -X POST.*curl -X POST'
 
   - it: should handle special characters in filter values correctly
     set:

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -255,6 +255,11 @@
                   }
                 }
               },
+              "enableV1": {
+                "type": "boolean",
+                "description": "When true, all test definitions are bundled into a single curl POST with a {\"Tests\":[...]} payload sent to the v1 endpoint. When false (default), each test definition generates a separate curl call to the legacy endpoint.",
+                "default": false
+              },
               "testdefinitions": {
                 "type": "array",
                 "description": "Test definitions to run",

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -480,7 +480,8 @@ applications: {}
 #     backoffLimit: 0
 #     apikey: "vault:Secrets/data/testengine#apikey"
 #     webhook_url: "vault:Secrets/data/testengine#webhook_url"
-#     
+#     enableV1: true                             # true: single bundled POST {"Tests":[...]} to api/v1 endpoint
+#                                                # false (default): one POST per testdefinition to legacy endpoint
 #     resources:
 #       requests:
 #         cpu: "50m"
@@ -488,7 +489,7 @@ applications: {}
 #       limits:
 #         cpu: "500m"
 #         memory: "512Mi"
-#     
+#
 #     testdefinitions:
 #       - name: "apitests"
 #         containerImage: "myregistry.example.com/image/name"
@@ -519,7 +520,7 @@ applications: {}
 #             effect: "NoSchedule"
 #         # Optional: Node affinity for test pods (default: [])
 #         nodeAffinity: []
-#       
+#
 #       - name: "somedependencytest"
 #         containerImage: "myregistry.example.com/image/name"
 #         containerTag: "1.10.2"


### PR DESCRIPTION
# feat: add enableV1 option for test triggers with bundled curl payload

## What changed

### New `enableV1` flag on `testtrigger`

Added an `enableV1` boolean option (default: `false`) under each application's `testtrigger` configuration. This controls how test definitions are sent to the test engine API:

| `enableV1` | Behaviour | Default webhook endpoint |
|---|---|---|
| `false` (default) | One curl POST per `testdefinition` — legacy wire format | `vault:DevOps/data/testengine/api#url` |
| `true` | Single curl POST with all definitions bundled in a `{"Tests":[...]}` payload | `vault:DevOps/data/testengine/api/v1#url` |

The webhook endpoint default is automatically selected based on the flag. `global.testengineWebhookUrl` (injected by the CI/CD render step) and an explicit `testtrigger.webhook_url` both still override the default at their respective precedence levels.

### v1 payload shape

```json
{
  "Tests": [
    {
      "IsMonolith": false,
      "TestName": "apitests",
      "StackName": "example",
      "ContainerImage": "testing/mc/example/automatedtests/tests",
      "ContainerTag": "26.20.41f8b8a",
      "TestFilters": "vault:QA/data/dev/mcexample#categoryapifilters",
      "Tolerations": [{"effect":"NoSchedule","key":"kubernetes.azure.com/scalesetpriority","operator":"Equal","value":"spot"}],
      "NodeAffinity": [],
      "UseDefaultNodeAffinity": "false",
      "SpreadAcrossNodes": "true",
      "PodResources": {"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"250m","memory":"0.5Gi"}},
      "TestEnvironmentVariables": {
        "EnvironmentName": "dev",
        "ReleaseId": "26.20.3399ae9",
        "SecretId": "vault:QA/data/app_auth#SecretId",
        "ServiceAddress": "http://example-api.dev.svc.cluster.local:8080",
        "ReleaseDefinitionName": "example-api",
        "BranchName": "integration",
        "AdditionalEnvVars": "",
        "CorrelationId": "f7e0c81b-7cb7-4ffc-8f83-827768467bf0",
        "LegacyMode": "false"
      }
    },
    { ... }
  ]
}
```

### Other changes

- **Image pinned**: `alpine/curl:latest` → `alpine/curl:8.17.0`
- **Schema**: `enableV1` added to `testtrigger` properties in `values.schema.json`
- **Docs**: `TestTriggersGuide.md` updated — configuration structure, parameters table, and behaviour description all reflect the new flag
- **values.yaml**: `enableV1` added to the commented example with inline explanation

## Files changed

| File | Change |
|---|---|
| `charts/mycarrier-helm/templates/_spec_triggertestengine.tpl` | Core logic — `enableV1` flag, branched command block, pinned image |
| `charts/mycarrier-helm/values.schema.json` | `enableV1: boolean, default: false` added to testtrigger |
| `charts/mycarrier-helm/values.yaml` | `enableV1` added to commented example |
| `charts/mycarrier-helm/TestTriggersGuide.md` | Updated overview, parameters table, and multi-app example explanation |
| `charts/mycarrier-helm/tests/triggertests_test.yaml` | 3 new test cases (v1 bundled, legacy explicit, legacy default); existing multi-test case strengthened |

## Testing

- `helm unittest` — **489/489 tests pass** across all 53 suites
- Rendered output verified in `ignore/render-triggertestengine/` for both modes:
  - `enableV1: true` — single curl, pretty-printed `{"Tests":[...]}` payload, `api/v1` URL
  - `enableV1: false` — one curl per testdefinition, legacy payload, `api` URL

## Migration

No breaking changes. Existing configurations without `enableV1` continue to work exactly as before (legacy mode).

To opt in to the new v1 endpoint, add `enableV1: true` to your `testtrigger` block:

```yaml
testtrigger:
  enableV1: true
  testdefinitions:
    - name: apitests
      ...
```
