### PR TITLE
VirtualService: support template interpolation across all generation paths

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.1.13
+version: 3.2.0
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
@@ -36,7 +36,7 @@ hosts:
 {{- $istioConfig := dig "networking" "istio" dict $primaryAppValues -}}
 {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts -}}
 {{- range $istioConfig.hosts }}
-- {{ . }}
+- {{ tpl . $ }}
 {{- end -}}
 {{- end -}}
 {{- end }}
@@ -123,10 +123,10 @@ http:
 {{- range $key, $value := $appValues.networking.istio.routes }}
 {{- $routeSpec := omit $value "destination" }}
 - name: {{ $key }}-custom-route
-  {{- toYaml $routeSpec | nindent 2 }}
+  {{- tpl (toYaml $routeSpec) $ | nindent 2 }}
   route:
   - destination:
-      host: "{{ default (printf "%s.%s.svc.cluster.local" $routeFullName $namespace) $value.destination }}"
+      host: "{{ tpl (default (printf "%s.%s.svc.cluster.local" $routeFullName $namespace) $value.destination) $ }}"
       port:
         number: 80
   {{ $headersBlock := include "helm.istioIngress.responseHeaders" $ }}
@@ -311,13 +311,33 @@ hosts:
 {{- $istioConfig := dig "networking" "istio" dict $primaryAppValues -}}
 {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts -}}
 {{- range $istioConfig.hosts }}
-- {{ . }}
+- {{ tpl . $ }}
 {{- end -}}
 {{- end }}
 gateways:
 - mesh
 - istio-system/default
 http:
+{{/* Custom routes (networking.istio.routes) for any frontend app - env-gated, most specific first.
+     The offload VS also binds the shared frontend host, so every route must match the environment
+     header to avoid hijacking shared traffic for all environments. */}}
+{{- range $appName, $appValues := $frontendApps }}
+{{- $routes := dig "networking" "istio" "routes" dict $appValues }}
+{{- range $key, $value := $routes }}
+{{- $routeFullName := include "helm.fullname" (merge (dict "appName" $appName "application" $appValues) $) }}
+- name: {{ $key }}-offload-custom-route
+  match:
+  {{- range $mi := ($value.match | default (list (dict))) }}
+  {{- $headers := merge (dict "environment" (dict "exact" $.Values.environment.name)) (deepCopy (dig "headers" dict $mi)) }}
+  - {{ tpl (toYaml (merge (dict "headers" $headers) (deepCopy (omit $mi "headers")))) $ | nindent 4 }}
+  {{- end }}
+  route:
+  - destination:
+      host: "{{ tpl (default (printf "%s.%s.svc.cluster.local" $routeFullName $namespace) $value.destination) $ }}"
+      port:
+        number: {{ default (default 4200 (dig "ports" "http" nil $appValues)) $value.port }}
+{{- end }}
+{{- end }}
 {{/* Path-based routing for feature environments */}}
 {{- range $appName, $appValues := $frontendApps }}
 {{- if and $appValues.routePrefix (ne $appValues.routePrefix "/") (not $appValues.isPrimary) }}

--- a/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
@@ -35,7 +35,7 @@ hosts:
 {{- $istioConfig := dig "networking" "istio" dict .application -}}
 {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts }}
 {{- range $istioConfig.hosts }}
-- {{ . }}
+- {{ tpl . $ }}
 {{- end }}
 {{- end }}
 gateways:
@@ -72,10 +72,10 @@ http:
 {{- range $key, $value := .application.networking.istio.routes }}
 {{- $routeSpec := omit $value "destination" "port" }}
 - name: {{ $key }}
-  {{- toYaml $routeSpec | nindent 2 }}
+  {{- tpl (toYaml $routeSpec) $ | nindent 2 }}
   route:
   - destination:
-      host: "{{ default (printf "%s.%s.svc.cluster.local" $fullName $namespace) $value.destination }}"
+      host: "{{ tpl (default (printf "%s.%s.svc.cluster.local" $fullName $namespace) $value.destination) $ }}"
       port:
         number: {{ default (default 8080 (dig "ports" "http" nil $.application)) $value.port }}
   {{- $routeHeaders := include "helm.istioIngress.responseHeaders" $ }}

--- a/charts/mycarrier-helm/templates/offloadBase.yaml
+++ b/charts/mycarrier-helm/templates/offloadBase.yaml
@@ -43,7 +43,7 @@ spec:
   {{- end }}
   {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts }}
   {{- range $istioConfig.hosts }}
-  - {{ . }}
+  - {{ tpl . $ }}
   {{- end }}
   {{- end }}
   gateways:

--- a/charts/mycarrier-helm/templates/virtualService.yaml
+++ b/charts/mycarrier-helm/templates/virtualService.yaml
@@ -61,13 +61,26 @@ spec:
   {{- /* Include additional custom hosts from networking.istio.hosts */ -}}
   {{- if and (hasKey $istioConfig "hosts") $istioConfig.hosts -}}
   {{- range $istioConfig.hosts }}
-  - {{ . }}
+  - {{ tpl . $ }}
   {{- end -}}
   {{- end }}
   gateways:
   - mesh
   - istio-system/default
   http:
+  {{- /* Custom routes (networking.istio.routes) - most specific first, before the catch-all */ -}}
+  {{- if and (hasKey $istioConfig "routes") $istioConfig.routes }}
+  {{- range $key, $value := $istioConfig.routes }}
+  {{- $routeSpec := omit $value "destination" "port" }}
+  - name: {{ $key }}
+    {{- tpl (toYaml $routeSpec) $ | nindent 4 }}
+    route:
+      - destination:
+          host: "{{ tpl (default (printf "%s.%s.svc.cluster.local" $fullName $namespace) $value.destination) $ }}"
+          port:
+            number: {{ default (default 8080 (dig "ports" "http" nil $appValues)) $value.port }}
+  {{- end }}
+  {{- end }}
   - name: {{ $fullName }}
     route:
       - destination:


### PR DESCRIPTION
## Summary

Enables `tpl` interpolation of values-sourced host/destination fields so a single values entry can target an environment-specific service across **every** VirtualService-generation path. Previously `{{ }}` placed in a values file rendered verbatim, because Helm does not template values files.

### Motivation

We need a path-based route to the same-environment `mycarrier-api` service without maintaining per-environment values:

| Environment | `<app-url>/MyCarrierApi` routes to |
|---|---|
| `feature19` | `mycarrier-api-feature19.feature19.svc.cluster.local` |
| `prod` | `mycarrier-api.prod.svc.cluster.local` |

The namespace and env-suffixed app name are already derivable from the chart's naming helpers — they just weren't reachable from values.

### What changed

- Route values now run through `tpl`, so `{{ include "helm.namespace" $ }}`, `{{ .Values.environment.name }}`, etc. resolve at render time.
- Applied consistently to **all** VS-generation paths:
  - single-app main VS and its offload VS
  - multi-frontend main VS and its offload VS
  - `OffloadBase` CRD (operator-generated VS)
- Fields covered: custom hosts (`networking.istio.hosts`), route `match` specs, and route destinations (`networking.istio.routes[].destination`).
- **Custom routes are now iterated in both offload specs** (they previously emitted only their default/primary routes). The multi-frontend offload VS binds the shared frontend host, so its custom routes are gated by the `environment` header to avoid hijacking shared traffic across environments; the single-app offload VS binds only feature-specific hosts and needs no gating. Routes are ordered ahead of the default/catch-all so path matches win.

### Example values

```yaml
networking:
  istio:
    routes:
      mycarrierapi:
        # set an explicit port for the API service if it differs from the app's http port
        destination: 'mycarrier-api{{ if hasPrefix "feature" .Values.environment.name }}-{{ .Values.environment.name }}{{ end }}.{{ include "helm.namespace" $ }}.svc.cluster.local'
        match:
          - uri:
              prefix: /MyCarrierApi
```

### Testing

- Rendered every path for `feature19` and `prod`; destinations and custom hosts interpolate as expected and routes are correctly ordered.
- `helm unittest .` — **506/506 pass**, no regressions.

### Notes / follow-ups

- Chart version bumped `3.1.13` → `3.2.0` (backward-compatible feature).
- `tpl` contract: a literal `{{` in any VS-related value is now treated as a template and must be valid. No existing fixtures hit this.
- Multi-frontend offload custom routes default the destination port to the frontend app's http port (4200) unless the route sets `port:` — specify it explicitly for `mycarrier-api`.
- Unit tests pinning the new interpolation/offload-route behavior would be a good follow-up.