### PR TITLE
feat: mc-environment config sync + mycarrier-helm whitelabelHost helper

### DIFF
--- a/charts/mc-environment/templates/appset.yaml
+++ b/charts/mc-environment/templates/appset.yaml
@@ -18,23 +18,9 @@ spec:
             - Values:
                 isEnvironmentDeploy: true
                 global:
-                  appStack: {{ $.Values.global.appStack | lower }}
-                  gitbranch: {{ $.Values.global.gitbranch }}
-                  branchlabel: {{ $.Values.global.branchlabel }}
-                  language: {{ $.Values.global.language }}
-                  v2migration: {{ $.Values.global.v2migration }}
-                  correlationId: {{ $.Values.global.correlationId | quote }}
-                  commitDeployed: {{ $.Values.global.commitDeployed | quote }}
-                  {{- $mergedEnv := deepCopy ($.Values.global.env | default dict) }}
-                  {{- if $env.global }}{{- if $env.global.env }}{{- $mergedEnv = mustMergeOverwrite $mergedEnv $env.global.env }}{{- end }}{{- end }}
-                  {{- if $mergedEnv }}
-                  env:
-                    {{- $mergedEnv | toYaml | nindent 20 }}
-                  {{- end }}
-                  {{ with $.Values.global.dependencies }}
-                  dependencies:
-                    {{- toYaml . | nindent 20 }}
-                  {{ end }}
+                  {{- $g := mustMergeOverwrite (deepCopy $.Values.global) ($env.global | default dict) }}
+                  {{- $_ := set $g "appStack" (lower ($g.appStack | default "")) }}
+                  {{- $g | toYaml | nindent 18 }}
                 environment:
                   {{- $envBlock := deepCopy ($env.environment | default dict) }}
                   {{- $_ := set $envBlock "name" $env.name }}

--- a/charts/mc-environment/templates/appset.yaml
+++ b/charts/mc-environment/templates/appset.yaml
@@ -36,8 +36,9 @@ spec:
                     {{- toYaml . | nindent 20 }}
                   {{ end }}
                 environment:
-                  name: {{ $env.name }}
-                  dependencyenv: {{ $env.dependencyenv | default "" }}
+                  {{- $envBlock := deepCopy ($env.environment | default dict) }}
+                  {{- $_ := set $envBlock "name" $env.name }}
+                  {{- $envBlock | toYaml | nindent 18 }}
                 enableVaultCA: {{ $env.enableVaultCA | default false }}
                 disableOtelAutoinstrumentation: {{ $env.disableOtelAutoinstrumentation | default false }}
                 tolerations: {{ $env.tolerations | default "[]" }}

--- a/charts/mc-environment/tests/appset_test.yaml
+++ b/charts/mc-environment/tests/appset_test.yaml
@@ -180,3 +180,23 @@ tests:
       - equal:
           path: spec.generators[0].list.elements[0].Values.global.appStack
           value: carriers
+  - it: accepts storage-account fields that mycarrier-helm permits
+    set:
+      global.appStack: carriers
+      environments:
+        - name: dev
+          infrastructure:
+            azure:
+              storage:
+                accounts:
+                  - name: shipmentsdata
+                    sku: Standard_LRS
+                    newStorageAccount:
+                      name: shipmentsdata
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.infrastructure.azure.storage.accounts[0].sku
+          value: Standard_LRS

--- a/charts/mc-environment/tests/appset_test.yaml
+++ b/charts/mc-environment/tests/appset_test.yaml
@@ -131,3 +131,28 @@ tests:
       - equal:
           path: spec.template.spec.syncPolicy.syncOptions[6]
           value: Replace=true
+  - it: forwards the environment block (dependencyenv, namespaceOverride, domainOverride)
+    values:
+      - fixtures/environment-overrides.yaml
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.name
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.dependencyenv
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.namespaceOverride
+          value: platform-dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.domainOverride.enabled
+          value: true
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.domainOverride.domain
+          value: example.dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.applications.shipments-api.staticHostname
+          value: api

--- a/charts/mc-environment/tests/appset_test.yaml
+++ b/charts/mc-environment/tests/appset_test.yaml
@@ -156,3 +156,27 @@ tests:
       - equal:
           path: spec.generators[0].list.elements[0].Values.applications.shipments-api.staticHostname
           value: api
+  - it: merges per-environment global overrides over the base global
+    set:
+      global.appStack: Carriers
+      global.gitbranch: main
+      global.dependencies.redis: false
+      environments:
+        - name: dev
+          global:
+            gitbranch: dev
+            dependencies:
+              redis: true
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.gitbranch
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.dependencies.redis
+          value: true
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.appStack
+          value: carriers

--- a/charts/mc-environment/tests/fixtures/environment-overrides.yaml
+++ b/charts/mc-environment/tests/fixtures/environment-overrides.yaml
@@ -1,0 +1,19 @@
+global:
+  appStack: carriers
+  gitbranch: main
+  language: nodejs
+environments:
+  - name: dev
+    environment:
+      dependencyenv: dev
+      namespaceOverride: platform-dev
+      domainOverride:
+        enabled: true
+        domain: example.dev
+    applications:
+      shipments-api:
+        staticHostname: api
+        image:
+          registry: ghcr.io
+          repository: mycarrier/shipments-api
+          tag: "1.12.3"

--- a/charts/mc-environment/values.schema.json
+++ b/charts/mc-environment/values.schema.json
@@ -314,13 +314,7 @@
       }
     },
     "infrastructure": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "azure": {
-          "$ref": "#/definitions/infrastructureAzure"
-        }
-      }
+      "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/infrastructure"
     },
     "enableVaultCA": {
       "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/enableVaultCA"

--- a/charts/mc-environment/values.schema.json
+++ b/charts/mc-environment/values.schema.json
@@ -118,6 +118,9 @@
         },
         "domainOverride": {
           "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/environment/properties/domainOverride"
+        },
+        "namespaceOverride": {
+          "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/environment/properties/namespaceOverride"
         }
       }
     },

--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.2.0
+version: 3.3.0
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -422,6 +422,30 @@ networking:
       maxAge: "24h"
 ```
 
+#### Whitelabel hosts
+
+Use the `helm.whitelabelHost` helper to publish a label on the environment's domain without
+hardcoding it. It renders `<label>.<domain>` in `prod`/`preprod`/`dev` and `<label>.<env>.<domain>`
+in every other environment (`qa`, `uat`, `feature*`). The domain follows
+`environment.domainOverride`.
+
+```yaml
+networking:
+  istio:
+    hosts:
+      - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+```
+
+| environment | rendered host |
+|---|---|
+| `prod` | `estes.mycarriertms.com` |
+| `dev` / `preprod` | `estes.mycarrier.dev` |
+| `feature20` | `estes.feature20.mycarrier.dev` |
+| `feature20` + `domainOverride: integratedtm.dev` | `estes.feature20.integratedtm.dev` |
+
+> Note: `{{ $domain }}` does **not** resolve inside a host value (it is a template-internal
+> variable). Use `{{ include "helm.domain" $ }}` or the `helm.whitelabelHost` helper instead.
+
 ### Secrets Management
 
 The chart integrates with Vault for secrets management:

--- a/charts/mycarrier-helm/templates/_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.tpl
@@ -17,9 +17,14 @@
 {{- end -}}
 {{- end -}}
 
+{{/* Build a whitelabel VirtualService host from a label and the environment-resolved domain.
+     Renders <label>.<domain> in prod/preprod/dev and <label>.<env>.<domain> elsewhere.
+     Call from a (tpl-evaluated) networking.istio.hosts entry:
+       {{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}
+     ctx must be the root context ($); domain follows environment.domainOverride. */}}
 {{- define "helm.whitelabelHost" -}}
 {{- $label := required "helm.whitelabelHost requires a label" .label -}}
-{{- $ctx := .ctx -}}
+{{- $ctx := required "helm.whitelabelHost requires ctx (pass \"ctx\" $)" .ctx -}}
 {{- $env := $ctx.Values.environment.name -}}
 {{- $domain := include "helm.domain" $ctx -}}
 {{- if has $env (list "prod" "preprod" "dev") -}}

--- a/charts/mycarrier-helm/templates/_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.tpl
@@ -17,6 +17,18 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "helm.whitelabelHost" -}}
+{{- $label := required "helm.whitelabelHost requires a label" .label -}}
+{{- $ctx := .ctx -}}
+{{- $env := $ctx.Values.environment.name -}}
+{{- $domain := include "helm.domain" $ctx -}}
+{{- if has $env (list "prod" "preprod" "dev") -}}
+{{- printf "%s.%s" $label $domain -}}
+{{- else -}}
+{{- printf "%s.%s.%s" $label $env $domain -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "helm.domain.prefix" -}}
 {{/* Get standardized context with defaults - use cached version if available */}}
 {{- $ctx := .ctx -}}

--- a/charts/mycarrier-helm/tests/virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/virtualservice_test.yaml
@@ -923,3 +923,25 @@ tests:
       - contains:
           path: spec.hosts
           content: teststack-test-app-feature-test-branch.dev.mycarrier.dev
+
+  - it: should combine staticHostname with an overridden domain
+    set:
+      environment.name: "prod"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "custom.com"
+      applications.combo-api.deploymentType: deployment
+      applications.combo-api.isFrontend: false
+      applications.combo-api.staticHostname: "foo"
+      applications.combo-api.image.registry: "myregistry.example.com"
+      applications.combo-api.image.repository: "mycarrier/combo-api"
+      applications.combo-api.image.tag: "1.0.0"
+      applications.combo-api.ports.http: 8080
+      applications.combo-api.networking.ingress.type: "istio"
+      applications.combo-api.networking.istio.enabled: true
+      applications.combo-api.networking.istio.offloadOperatorEnabled: false
+    asserts:
+      - isKind:
+          of: VirtualService
+      - contains:
+          path: spec.hosts
+          content: foo.custom.com

--- a/charts/mycarrier-helm/tests/whitelabel_host_test.yaml
+++ b/charts/mycarrier-helm/tests/whitelabel_host_test.yaml
@@ -1,0 +1,167 @@
+suite: whitelabel host helper tests
+templates:
+  - virtualService.yaml
+tests:
+  - it: omits the env infix in dev
+    set:
+      environment.name: "dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - isKind:
+          of: VirtualService
+      - contains:
+          path: spec.hosts
+          content: estes.mycarrier.dev
+
+  - it: omits the env infix in prod (prod domain)
+    set:
+      environment.name: "prod"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.mycarriertms.com
+
+  - it: omits the env infix in preprod
+    set:
+      environment.name: "preprod"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.mycarrier.dev
+
+  - it: includes the env infix in a feature environment
+    set:
+      environment.name: "feature20"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.feature20.mycarrier.dev
+
+  - it: includes the env infix in qa (skip-set boundary)
+    set:
+      environment.name: "qa"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.qa.mycarrier.dev
+
+  - it: honors domainOverride on the infix branch
+    set:
+      environment.name: "feature20"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.feature20.integratedtm.dev
+
+  - it: honors domainOverride on the no-infix branch
+    set:
+      environment.name: "dev"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.integratedtm.dev
+
+  - it: coexists with staticHostname under a domainOverride
+    set:
+      environment.name: "dev"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.staticHostname: "api"
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: api.integratedtm.dev
+      - contains:
+          path: spec.hosts
+          content: estes.integratedtm.dev

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -233,6 +233,10 @@ applications: {}
 #       internalEnabled: true  # Enable internal ServiceEntry, WasmPlugin, and VirtualService internal host (default: true)
 #       offloadVSEnabled: true  # Enable the offload VirtualService for feature environments (default: true)
 #       cloudflareProxied: true  # Enable Cloudflare proxy for VirtualService DNS records (external-dns annotation, default: true)
+#       # Whitelabel hosts can use the helm.whitelabelHost helper to derive the domain:
+#       #   hosts:
+#       #     - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+#       # Renders estes.<domain> in prod/preprod/dev and estes.<env>.<domain> elsewhere.
 #       hosts: []
 #       redirects: {}
 #       routes: {}  # Custom routes; destination defaults to the app's service. Override with 'destination' field per route.

--- a/docs/superpowers/plans/2026-06-10-mc-environment-config-sync.md
+++ b/docs/superpowers/plans/2026-06-10-mc-environment-config-sync.md
@@ -1,0 +1,530 @@
+# mc-environment Config-Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mc-environment` faithfully represent mycarrier-helm's configuration surface — pass the `environment` and `global` blocks through (fixing dropped `dependencyenv`/`domainOverride`/`namespaceOverride` and per-env `global` overrides) and replace the drift-prone local `infrastructure` schema copy with a remote `$ref`.
+
+**Architecture:** `mc-environment/templates/appset.yaml` builds an ArgoCD `ApplicationSet` per environment whose `Values` block feeds the `mycarrier-helm` chart. Stop hand-building the `environment` and `global` sub-blocks; emit them with `toYaml` (injecting `name`, merging per-env `global`, preserving `appStack` lowercasing). In `mc-environment/values.schema.json`, complete `mycarrierEnvironmentOverride` and repoint the local `infrastructure` definition to mycarrier-helm's published schema.
+
+**Tech Stack:** Helm (Go templates + Sprig), helm-unittest, JSON Schema (draft-07).
+
+**Conventions:**
+- Run mc-environment tests from `charts/mc-environment`: `helm unittest -f 'tests/appset_test.yaml' .`
+- Run mycarrier-helm tests from `charts/mycarrier-helm`: `helm unittest -f 'tests/virtualservice_test.yaml' .`
+- Remote schema base URL (already used in this file):
+  `https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json`
+- Commit attribution: author/committer is the user only; no `Co-Authored-By`, no AI mentions.
+
+---
+
+## File Structure
+
+- `charts/mc-environment/templates/appset.yaml` — **modify**: `global` block (lines ~20-37) and `environment` block (lines ~38-40).
+- `charts/mc-environment/values.schema.json` — **modify**: `mycarrierEnvironmentOverride` (lines ~110-123, add `namespaceOverride`); `infrastructure` definition (lines ~313-321, repoint to remote).
+- `charts/mc-environment/tests/fixtures/environment-overrides.yaml` — **create**: fixture with a per-env `environment` block + an app with `staticHostname`.
+- `charts/mc-environment/tests/appset_test.yaml` — **modify**: add forwarding / merge / schema tests.
+- `charts/mycarrier-helm/tests/virtualservice_test.yaml` — **modify**: add the staticHostname + domainOverride combination test.
+
+---
+
+## Task 0: Probe remote-`$ref` enforcement (gating spike)
+
+**Why:** The schema repoint in Task 4 only works if Helm actually fetches and enforces remote `$ref`s. `environments[].enableVaultCA` is already a remote `$ref` to mycarrier-helm's `enableVaultCA` (a `boolean`/`null` `oneOf`), so we can probe enforcement with **no code change**.
+
+**Files:** none (investigation only).
+
+- [ ] **Step 1: Write a probe values file**
+
+```bash
+cat > /tmp/mc-probe.yaml <<'EOF'
+global:
+  appStack: carriers
+environments:
+  - name: dev
+    enableVaultCA: "not-a-boolean"
+EOF
+```
+
+- [ ] **Step 2: Render and observe**
+
+Run (from `charts/mc-environment`): `helm template . -f /tmp/mc-probe.yaml >/dev/null; echo "rc=$?"`
+
+- **If it FAILS** with a schema error about `enableVaultCA` (string vs boolean): remote `$ref`s ARE enforced. Proceed with Task 4 as written (remote repoint).
+- **If it SUCCEEDS** (`rc=0`): remote `$ref`s are NOT enforced by Helm's validator. Do **Task 4 (fallback)** instead of Task 4, and note in the commit that infrastructure stays a local copy with a targeted patch.
+
+- [ ] **Step 3: Record the outcome**
+
+Write the result (enforced / not enforced) into the Task 4 commit message so the decision is traceable. No commit for this task.
+
+---
+
+## Task 1: Pass the `environment` block through (appset.yaml)
+
+**Files:**
+- Create: `charts/mc-environment/tests/fixtures/environment-overrides.yaml`
+- Modify: `charts/mc-environment/templates/appset.yaml:38-40`
+- Test: `charts/mc-environment/tests/appset_test.yaml`
+
+- [ ] **Step 1: Create the fixture**
+
+Create `charts/mc-environment/tests/fixtures/environment-overrides.yaml`:
+
+```yaml
+global:
+  appStack: carriers
+  gitbranch: main
+  language: nodejs
+environments:
+  - name: dev
+    environment:
+      dependencyenv: dev
+      namespaceOverride: platform-dev
+      domainOverride:
+        enabled: true
+        domain: example.dev
+    applications:
+      shipments-api:
+        staticHostname: api
+        image:
+          registry: ghcr.io
+          repository: mycarrier/shipments-api
+          tag: "1.12.3"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `charts/mc-environment/tests/appset_test.yaml` (under `tests:`):
+
+```yaml
+  - it: forwards the environment block (dependencyenv, namespaceOverride, domainOverride)
+    values:
+      - fixtures/environment-overrides.yaml
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.name
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.dependencyenv
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.namespaceOverride
+          value: platform-dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.domainOverride.enabled
+          value: true
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.environment.domainOverride.domain
+          value: example.dev
+      # explicit spec ask: an app staticHostname AND an overridden domain both pass through
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.applications.shipments-api.staticHostname
+          value: api
+```
+
+- [ ] **Step 3: Run the test, verify it FAILS**
+
+Run (from `charts/mc-environment`): `helm unittest -f 'tests/appset_test.yaml' .`
+Expected: FAIL — `environment.dependencyenv` renders empty and `environment.domainOverride`/`namespaceOverride` are absent under the current hand-built block. (The `staticHostname` assertion already passes, since `applications` is a remote `$ref` passed through via `toYaml`; the suite still fails overall on the environment assertions, which is the RED we need.)
+
+- [ ] **Step 4: Implement the pass-through**
+
+In `charts/mc-environment/templates/appset.yaml`, replace these three lines:
+
+```gotemplate
+                environment:
+                  name: {{ $env.name }}
+                  dependencyenv: {{ $env.dependencyenv | default "" }}
+```
+
+with:
+
+```gotemplate
+                environment:
+                  {{- $envBlock := deepCopy ($env.environment | default dict) }}
+                  {{- $_ := set $envBlock "name" $env.name }}
+                  {{- $envBlock | toYaml | nindent 18 }}
+```
+
+- [ ] **Step 5: Run the test, verify it PASSES**
+
+Run (from `charts/mc-environment`): `helm unittest -f 'tests/appset_test.yaml' .`
+Expected: PASS, and all pre-existing tests still PASS (the `environment.name` assertions in the existing suite remain satisfied because `name` is injected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charts/mc-environment/templates/appset.yaml charts/mc-environment/tests/appset_test.yaml charts/mc-environment/tests/fixtures/environment-overrides.yaml
+git commit -m "fix(mc-environment): pass environment block through to mycarrier-helm
+
+Emit the whole environment block via toYaml with name injected, so
+dependencyenv, namespaceOverride and domainOverride reach mycarrier-helm
+instead of being dropped by the hand-built block."
+```
+
+---
+
+## Task 2: Merge and pass the `global` block through (appset.yaml)
+
+**Files:**
+- Modify: `charts/mc-environment/templates/appset.yaml:20-37`
+- Test: `charts/mc-environment/tests/appset_test.yaml`
+
+- [ ] **Step 1: Write the failing test (per-env global override)**
+
+Append to `charts/mc-environment/tests/appset_test.yaml`:
+
+```yaml
+  - it: merges per-environment global overrides over the base global
+    set:
+      global.appStack: Carriers
+      global.gitbranch: main
+      global.dependencies.redis: false
+      environments:
+        - name: dev
+          global:
+            gitbranch: dev
+            dependencies:
+              redis: true
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      # per-env override wins
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.gitbranch
+          value: dev
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.dependencies.redis
+          value: true
+      # appStack is forced lowercase
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.global.appStack
+          value: carriers
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run (from `charts/mc-environment`): `helm unittest -f 'tests/appset_test.yaml' .`
+Expected: FAIL — the current block reads `gitbranch`/`dependencies` from base `$.Values.global` only, so the per-env `gitbranch: dev` and `dependencies.redis: true` overrides are ignored.
+
+- [ ] **Step 3: Implement merged pass-through**
+
+In `charts/mc-environment/templates/appset.yaml`, replace this block:
+
+```gotemplate
+                global:
+                  appStack: {{ $.Values.global.appStack | lower }}
+                  gitbranch: {{ $.Values.global.gitbranch }}
+                  branchlabel: {{ $.Values.global.branchlabel }}
+                  language: {{ $.Values.global.language }}
+                  v2migration: {{ $.Values.global.v2migration }}
+                  correlationId: {{ $.Values.global.correlationId | quote }}
+                  commitDeployed: {{ $.Values.global.commitDeployed | quote }}
+                  {{- $mergedEnv := deepCopy ($.Values.global.env | default dict) }}
+                  {{- if $env.global }}{{- if $env.global.env }}{{- $mergedEnv = mustMergeOverwrite $mergedEnv $env.global.env }}{{- end }}{{- end }}
+                  {{- if $mergedEnv }}
+                  env:
+                    {{- $mergedEnv | toYaml | nindent 20 }}
+                  {{- end }}
+                  {{ with $.Values.global.dependencies }}
+                  dependencies:
+                    {{- toYaml . | nindent 20 }}
+                  {{ end }}
+```
+
+with:
+
+```gotemplate
+                global:
+                  {{- $g := mustMergeOverwrite (deepCopy $.Values.global) ($env.global | default dict) }}
+                  {{- $_ := set $g "appStack" (lower ($g.appStack | default "")) }}
+                  {{- $g | toYaml | nindent 18 }}
+```
+
+- [ ] **Step 4: Run the test, verify it PASSES**
+
+Run (from `charts/mc-environment`): `helm unittest -f 'tests/appset_test.yaml' .`
+Expected: PASS. Pre-existing global tests still PASS:
+- "forwards dev environment configuration" (`global.dependencies.redis: true`, `global.env.LOG_LEVEL: info`, `global.correlationId: test-corr-id-123`, `global.commitDeployed: abc1234`) — all present via the merged base global.
+- "forwards empty correlationId and commitDeployed when not set" — values.yaml defaults both to `""`, so the merged map still emits `correlationId: ""` / `commitDeployed: ""`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/mc-environment/templates/appset.yaml charts/mc-environment/tests/appset_test.yaml
+git commit -m "fix(mc-environment): merge per-env global overrides into the global block
+
+Deep-merge base global with the environment's global override and emit via
+toYaml (forcing appStack lowercase), so per-env gitbranch/dependencies/env
+overrides take effect instead of being silently dropped."
+```
+
+---
+
+## Task 3: Add `namespaceOverride` to the environment-override schema
+
+**Files:**
+- Modify: `charts/mc-environment/values.schema.json:119-122`
+- Test: `charts/mc-environment/tests/appset_test.yaml` (reuses `environment-overrides.yaml`, which already sets `namespaceOverride`)
+
+- [ ] **Step 1: Write the failing test (schema rejects namespaceOverride today)**
+
+The `environment-overrides.yaml` fixture sets `environment.namespaceOverride`, but `mycarrierEnvironmentOverride` does not declare it. Confirm the current schema rejects it:
+
+Run (from `charts/mc-environment`): `helm template . -f tests/fixtures/environment-overrides.yaml >/dev/null; echo "rc=$?"`
+Expected: FAIL (`rc` non-zero) with a schema error: additional property `namespaceOverride` not allowed under the environment block.
+
+> Note: if Task 0 found remote `$ref`s are NOT enforced, this step may unexpectedly pass. In that case skip to Step 2 (the schema addition is still correct and harmless) and treat Step 4 as a render smoke-test only.
+
+- [ ] **Step 2: Add the property**
+
+In `charts/mc-environment/values.schema.json`, inside `mycarrierEnvironmentOverride.properties`, replace:
+
+```json
+        "domainOverride": {
+          "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/environment/properties/domainOverride"
+        }
+      }
+```
+
+with:
+
+```json
+        "domainOverride": {
+          "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/environment/properties/domainOverride"
+        },
+        "namespaceOverride": {
+          "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/environment/properties/namespaceOverride"
+        }
+      }
+```
+
+- [ ] **Step 3: Validate the JSON is well-formed**
+
+Run (from `charts/mc-environment`): `python3 -m json.tool values.schema.json >/dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Render the fixture, verify it now validates**
+
+Run (from `charts/mc-environment`): `helm template . -f tests/fixtures/environment-overrides.yaml >/dev/null; echo "rc=$?"`
+Expected: `rc=0`. Then re-run the suite: `helm unittest -f 'tests/appset_test.yaml' .` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/mc-environment/values.schema.json
+git commit -m "feat(mc-environment): allow environment.namespaceOverride in schema
+
+Add namespaceOverride to mycarrierEnvironmentOverride via remote \$ref to
+mycarrier-helm, matching the other environment properties."
+```
+
+---
+
+## Task 4: Repoint the local `infrastructure` schema to mycarrier-helm (remote)
+
+**Precondition:** Task 0 found remote `$ref`s ARE enforced. If NOT, do **Task 4 (fallback)** below instead.
+
+**Files:**
+- Modify: `charts/mc-environment/values.schema.json:313-321`
+- Test: `charts/mc-environment/tests/appset_test.yaml`
+
+- [ ] **Step 1: Write the failing test (a field mycarrier-helm permits but the local copy rejects)**
+
+mycarrier-helm's storage account allows additional properties; the local copy sets `additionalProperties: false`. Append to `charts/mc-environment/tests/appset_test.yaml`:
+
+```yaml
+  - it: accepts storage-account fields that mycarrier-helm permits
+    set:
+      global.appStack: carriers
+      environments:
+        - name: dev
+          infrastructure:
+            azure:
+              storage:
+                accounts:
+                  - name: shipmentsdata
+                    sku: Standard_LRS
+                    newStorageAccount:
+                      name: shipmentsdata
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.infrastructure.azure.storage.accounts[0].sku
+          value: Standard_LRS
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run (from `charts/mc-environment`): `helm unittest -f 'tests/appset_test.yaml' .`
+Expected: FAIL — schema error: additional property `sku` not allowed on the storage account (local `additionalProperties: false`).
+
+- [ ] **Step 3: Repoint the definition to the remote schema**
+
+In `charts/mc-environment/values.schema.json`, replace:
+
+```json
+    "infrastructure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "azure": {
+          "$ref": "#/definitions/infrastructureAzure"
+        }
+      }
+    },
+```
+
+with:
+
+```json
+    "infrastructure": {
+      "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/infrastructure"
+    },
+```
+
+> The `infrastructureAzure*` definitions become unreferenced (dead) but are harmless. Leave them; a separate cleanup PR can remove them to avoid a large diff here.
+
+- [ ] **Step 4: Validate JSON + run tests**
+
+Run (from `charts/mc-environment`):
+```bash
+python3 -m json.tool values.schema.json >/dev/null && echo OK
+helm unittest -f 'tests/appset_test.yaml' .
+```
+Expected: `OK`; suite PASSES (the `sku` test now passes; the existing `newStorageAccount.name`/`containers` assertions still pass because the remote schema is a superset).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/mc-environment/values.schema.json charts/mc-environment/tests/appset_test.yaml
+git commit -m "feat(mc-environment): validate infrastructure against mycarrier-helm schema
+
+Repoint the local infrastructure definition to mycarrier-helm's published
+schema (remote \$ref), so any field mycarrier-helm accepts (e.g. storage sku)
+validates here and stays in sync. Remote-\$ref enforcement confirmed in Task 0."
+```
+
+---
+
+## Task 4 (fallback): Targeted local infrastructure patch
+
+**Use only if Task 0 found remote `$ref`s are NOT enforced.** Keeping a local copy that's actually enforced is better than a remote ref that's silently ignored.
+
+**Files:**
+- Modify: `charts/mc-environment/values.schema.json` — `infrastructureAzureStorageAccount` definition (the storage-account object).
+
+- [ ] **Step 1: Write the failing test**
+
+Use the exact same test from Task 4 Step 1 ("accepts storage-account fields that mycarrier-helm permits").
+
+- [ ] **Step 2: Run the test, verify it FAILS** (same as Task 4 Step 2).
+
+- [ ] **Step 3: Open the storage account to additional properties**
+
+In `charts/mc-environment/values.schema.json`, find the `infrastructureAzureStorageAccount` definition and change its `"additionalProperties": false` to `"additionalProperties": true` (mycarrier-helm permits extra storage-account fields). Make the same change to `infrastructureAzureNewStorageAccount` if the offending field nests there.
+
+- [ ] **Step 4: Validate JSON + run tests** (same commands as Task 4 Step 4). Expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/mc-environment/values.schema.json charts/mc-environment/tests/appset_test.yaml
+git commit -m "fix(mc-environment): align storage-account schema with mycarrier-helm
+
+Helm does not enforce remote \$refs (confirmed in Task 0), so patch the local
+infrastructure copy to permit the extra storage-account fields mycarrier-helm
+accepts instead of repointing to a remote schema that would be ignored."
+```
+
+---
+
+## Task 5: Prove staticHostname + domainOverride combine (mycarrier-helm)
+
+**Files:**
+- Test: `charts/mycarrier-helm/tests/virtualservice_test.yaml`
+
+- [ ] **Step 1: Write the test**
+
+Append to `charts/mycarrier-helm/tests/virtualservice_test.yaml` (under `tests:`):
+
+```yaml
+  - it: should combine staticHostname with an overridden domain
+    set:
+      environment.name: "prod"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "custom.com"
+      applications.combo-api.deploymentType: deployment
+      applications.combo-api.isFrontend: false
+      applications.combo-api.staticHostname: "foo"
+      applications.combo-api.image.registry: "myregistry.example.com"
+      applications.combo-api.image.repository: "mycarrier/combo-api"
+      applications.combo-api.image.tag: "1.0.0"
+      applications.combo-api.ports.http: 8080
+      applications.combo-api.networking.ingress.type: "istio"
+      applications.combo-api.networking.istio.enabled: true
+      applications.combo-api.networking.istio.offloadOperatorEnabled: false
+    asserts:
+      - isKind:
+          of: VirtualService
+      # staticHostname (foo) joined to the overridden domain (custom.com)
+      - contains:
+          path: spec.hosts
+          content: foo.custom.com
+```
+
+- [ ] **Step 2: Run the test, verify it PASSES**
+
+Run (from `charts/mycarrier-helm`): `helm unittest -f 'tests/virtualservice_test.yaml' .`
+Expected: PASS. (`helm.domain` short-circuits to `domainOverride.domain` when enabled; the non-feature `staticHostname` branch emits `foo.custom.com`.) This is an existing-behavior characterization test — it documents the combination works end-to-end.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add charts/mycarrier-helm/tests/virtualservice_test.yaml
+git commit -m "test(virtualservice): cover staticHostname combined with domainOverride"
+```
+
+---
+
+## Task 6: Full regression + finish
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Run both chart suites**
+
+```bash
+( cd charts/mc-environment && helm unittest . )
+( cd charts/mycarrier-helm && helm unittest . )
+```
+Expected: all suites PASS in both charts.
+
+- [ ] **Step 2: Render the original example to confirm the reported gap is closed**
+
+Run (from `charts/mc-environment`): `helm template . -f tests/fixtures/environment-overrides.yaml >/dev/null; echo "rc=$?"`
+Expected: `rc=0`, and the rendered `Values.environment` contains `dependencyenv`, `namespaceOverride`, and `domainOverride`.
+
+- [ ] **Step 3: Use the finishing-a-development-branch skill** to decide how to integrate (PR vs merge) — do not push or open a PR without explicit user direction.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- environment pass-through + inject name → Task 1. ✓
+- global merged pass-through (appStack lower, correlationId/commitDeployed defaults) → Task 2 (defaults come from values.yaml; verified in Step 4). ✓
+- schema: namespaceOverride → Task 3; infrastructure remote `$ref` → Task 4 (+ fallback). ✓
+- remote-`$ref` enforcement unknown → Task 0 gate + Task 4 fallback. ✓
+- tests: domainOverride/namespaceOverride/dependencyenv forwarding → Task 1; per-env global merge → Task 2; staticHostname + domainOverride pass-through → fixture (`environment-overrides.yaml` sets both) asserted in Task 1 + the mycarrier-helm combination → Task 5; previously-rejected infra field → Task 4. ✓
+- exclusion of `isEnvironmentDeploy=false`-only config → no such config is touched. ✓
+
+**Placeholder scan:** none — every step has exact paths, code, commands, expected output.
+
+**Type/name consistency:** template var names (`$envBlock`, `$g`) are self-contained per task; remote URL string identical across Tasks 3 and 4; fixture filename `environment-overrides.yaml` consistent across Tasks 1, 3, 6.
+
+**staticHostname+domainOverride pass-through:** covered non-optionally in Task 1 Step 2 — the fixture sets both an app `staticHostname: api` and `environment.domainOverride`, and the test asserts both reach the generated `Values`. The mycarrier-helm side (that they combine into `foo.custom.com`) is Task 5.

--- a/docs/superpowers/plans/2026-06-10-whitelabel-host-helper.md
+++ b/docs/superpowers/plans/2026-06-10-whitelabel-host-helper.md
@@ -1,0 +1,353 @@
+# helm.whitelabelHost Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `helm.whitelabelHost` named template to mycarrier-helm that builds a whitelabel VirtualService host (`<label>.<domain>`, with a `.<env>` infix outside prod/preprod/dev) using the environment-resolved domain, callable from `networking.istio.hosts`.
+
+**Architecture:** `networking.istio.hosts` entries are already evaluated via `tpl . $` in every VirtualService path, so adding the helper requires NO template-path changes — only the helper definition plus tests and docs. The helper takes `{label, ctx}` where `ctx` is the root `$`, derives the domain from `helm.domain` (honoring `environment.domainOverride`), and conditionally inserts the env infix.
+
+**Tech Stack:** Helm (Go templates + Sprig), helm-unittest.
+
+**Conventions:**
+- Run mycarrier-helm tests from `charts/mycarrier-helm`: `helm unittest -f 'tests/<file>' .`
+- Work on branch `feat/mc-environment-config-sync` (already checked out). Do NOT touch `main`.
+- Commit attribution: the repo's git user only; no `Co-Authored-By`, no AI mentions.
+
+---
+
+## File Structure
+
+- `charts/mycarrier-helm/templates/_helpers.tpl` — **modify**: add the `helm.whitelabelHost` define (next to `helm.domain`, near the top).
+- `charts/mycarrier-helm/tests/whitelabel_host_test.yaml` — **create**: the helper's test suite (targets `virtualService.yaml`).
+- `charts/mycarrier-helm/README.md` — **modify**: add a usage example in the istio hosts documentation.
+- `charts/mycarrier-helm/values.yaml` — **modify**: add a commented example on `networking.istio.hosts`.
+
+---
+
+## Task 1: Add the `helm.whitelabelHost` helper (TDD)
+
+**Files:**
+- Create: `charts/mycarrier-helm/tests/whitelabel_host_test.yaml`
+- Modify: `charts/mycarrier-helm/templates/_helpers.tpl`
+
+- [ ] **Step 1: Write the failing test suite.** Create `charts/mycarrier-helm/tests/whitelabel_host_test.yaml`:
+
+```yaml
+suite: whitelabel host helper tests
+templates:
+  - virtualService.yaml
+tests:
+  - it: omits the env infix in dev
+    set:
+      environment.name: "dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - isKind:
+          of: VirtualService
+      - contains:
+          path: spec.hosts
+          content: estes.mycarrier.dev
+
+  - it: omits the env infix in prod (prod domain)
+    set:
+      environment.name: "prod"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.mycarriertms.com
+
+  - it: omits the env infix in preprod
+    set:
+      environment.name: "preprod"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.mycarrier.dev
+
+  - it: includes the env infix in a feature environment
+    set:
+      environment.name: "feature20"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.feature20.mycarrier.dev
+
+  - it: includes the env infix in qa (skip-set boundary)
+    set:
+      environment.name: "qa"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.qa.mycarrier.dev
+
+  - it: honors domainOverride on the infix branch
+    set:
+      environment.name: "feature20"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.feature20.integratedtm.dev
+
+  - it: honors domainOverride on the no-infix branch
+    set:
+      environment.name: "dev"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: estes.integratedtm.dev
+
+  - it: coexists with staticHostname under a domainOverride
+    set:
+      environment.name: "dev"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "integratedtm.dev"
+      applications.wl-api.deploymentType: deployment
+      applications.wl-api.isFrontend: false
+      applications.wl-api.staticHostname: "api"
+      applications.wl-api.image.registry: "r"
+      applications.wl-api.image.repository: "mycarrier/wl-api"
+      applications.wl-api.image.tag: "1.0.0"
+      applications.wl-api.ports.http: 8080
+      applications.wl-api.networking.ingress.type: "istio"
+      applications.wl-api.networking.istio.enabled: true
+      applications.wl-api.networking.istio.offloadOperatorEnabled: false
+      applications.wl-api.networking.istio.hosts:
+        - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+    asserts:
+      # static host uses the overridden domain
+      - contains:
+          path: spec.hosts
+          content: api.integratedtm.dev
+      # whitelabel helper host also present, also on the overridden domain (dev = no infix)
+      - contains:
+          path: spec.hosts
+          content: estes.integratedtm.dev
+```
+
+- [ ] **Step 2: Run the suite, confirm it FAILS for the right reason.**
+
+Run (from `charts/mycarrier-helm`): `helm unittest -f 'tests/whitelabel_host_test.yaml' .`
+Expected: FAIL/ERROR — the template `helm.whitelabelHost` is not defined, so `tpl` errors while rendering the host (e.g. `template ... helm.whitelabelHost ... not defined`). If it PASSES, STOP and report BLOCKED (the helper may already exist).
+
+- [ ] **Step 3: Add the helper.** In `charts/mycarrier-helm/templates/_helpers.tpl`, add this block immediately AFTER the closing `{{- end -}}` of the `helm.domain` definition (the `helm.domain` define is near the top of the file, lines ~1-18):
+
+```gotemplate
+
+{{- define "helm.whitelabelHost" -}}
+{{- $label := required "helm.whitelabelHost requires a label" .label -}}
+{{- $ctx := .ctx -}}
+{{- $env := $ctx.Values.environment.name -}}
+{{- $domain := include "helm.domain" $ctx -}}
+{{- if has $env (list "prod" "preprod" "dev") -}}
+{{- printf "%s.%s" $label $domain -}}
+{{- else -}}
+{{- printf "%s.%s.%s" $label $env $domain -}}
+{{- end -}}
+{{- end -}}
+```
+
+- [ ] **Step 4: Run the suite, confirm all 8 tests PASS.**
+
+Run (from `charts/mycarrier-helm`): `helm unittest -f 'tests/whitelabel_host_test.yaml' .`
+Expected: PASS, 8/8.
+
+- [ ] **Step 5: Run the full chart suite to confirm no regressions.**
+
+Run (from `charts/mycarrier-helm`): `helm unittest .`
+Expected: all suites pass.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add charts/mycarrier-helm/templates/_helpers.tpl charts/mycarrier-helm/tests/whitelabel_host_test.yaml
+git commit -m "feat(virtualservice): add helm.whitelabelHost template helper
+
+Build a whitelabel host (<label>.<domain>, with a .<env> infix outside
+prod/preprod/dev) from the environment-resolved domain, callable from
+networking.istio.hosts. Honors environment.domainOverride."
+```
+
+---
+
+## Task 2: Document the helper
+
+**Files:**
+- Modify: `charts/mycarrier-helm/README.md`
+- Modify: `charts/mycarrier-helm/values.yaml`
+
+- [ ] **Step 1: Locate the istio hosts documentation in `charts/mycarrier-helm/README.md`.**
+
+Run: `grep -n "networking.istio.hosts\|istio:" charts/mycarrier-helm/README.md | head`
+Identify the section that documents `networking.istio.hosts` (custom VirtualService hosts). If no such section exists, add the example under the nearest Istio/VirtualService heading.
+
+- [ ] **Step 2: Add this documentation block** in that section (verbatim):
+
+````markdown
+#### Whitelabel hosts
+
+Use the `helm.whitelabelHost` helper to publish a label on the environment's domain without
+hardcoding it. It renders `<label>.<domain>` in `prod`/`preprod`/`dev` and `<label>.<env>.<domain>`
+in every other environment (`qa`, `uat`, `feature*`). The domain follows
+`environment.domainOverride`.
+
+```yaml
+networking:
+  istio:
+    hosts:
+      - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+```
+
+| environment | rendered host |
+|---|---|
+| `prod` | `estes.mycarriertms.com` |
+| `dev` / `preprod` | `estes.mycarrier.dev` |
+| `feature20` | `estes.feature20.mycarrier.dev` |
+| `feature20` + `domainOverride: integratedtm.dev` | `estes.feature20.integratedtm.dev` |
+
+> Note: `{{ $domain }}` does **not** resolve inside a host value (it is a template-internal
+> variable). Use `{{ include "helm.domain" $ }}` or the `helm.whitelabelHost` helper instead.
+````
+
+- [ ] **Step 3: Add a commented example to `charts/mycarrier-helm/values.yaml`.**
+
+Run: `grep -n "hosts:" charts/mycarrier-helm/values.yaml | head` to find the `networking.istio.hosts` key (or its documentation comment). Immediately adjacent to it, add this comment (match the file's existing comment indentation):
+
+```yaml
+        # Whitelabel hosts can use the helm.whitelabelHost helper to derive the domain:
+        #   hosts:
+        #     - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+        # Renders estes.<domain> in prod/preprod/dev and estes.<env>.<domain> elsewhere.
+```
+
+If `networking.istio.hosts` is not present in `values.yaml`, add the comment under the existing `networking.istio` documentation block instead. Do not add a live (uncommented) `hosts` value.
+
+- [ ] **Step 4: Sanity-check the chart still templates and tests pass.**
+
+Run (from `charts/mycarrier-helm`):
+```bash
+helm template . >/dev/null && echo "template OK"
+helm unittest -f 'tests/whitelabel_host_test.yaml' .
+```
+Expected: `template OK`; suite 8/8 (docs changes must not affect rendering).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add charts/mycarrier-helm/README.md charts/mycarrier-helm/values.yaml
+git commit -m "docs(virtualservice): document helm.whitelabelHost usage"
+```
+
+---
+
+## Task 3: Bump chart version
+
+**Files:**
+- Modify: `charts/mycarrier-helm/Chart.yaml`
+
+- [ ] **Step 1: Read the current version.**
+
+Run: `grep -n '^version:' charts/mycarrier-helm/Chart.yaml`
+
+- [ ] **Step 2: Bump the minor version** (new backward-compatible feature). Edit `charts/mycarrier-helm/Chart.yaml` `version:` from `3.2.0` to `3.3.0`. If the current version is not `3.2.0`, bump the minor component of whatever the current version is (e.g. `X.Y.Z` → `X.(Y+1).0`) and note the actual values in the commit.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add charts/mycarrier-helm/Chart.yaml
+git commit -m "chore(mycarrier-helm): bump chart version for whitelabelHost helper"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Helper definition (label + ctx, helm.domain, skip-set prod/preprod/dev, required label) → Task 1 Step 3. ✓
+- No template-path changes (hosts already tpl'd) → reflected: only `_helpers.tpl` touched. ✓
+- All 8 spec test cases (dev, prod, preprod, feature20, qa, override+infix, override+no-infix, override+staticHostname) → Task 1 Step 1 has all 8. ✓
+- Docs (README + values.yaml, incl. the `$domain` note) → Task 2. ✓
+- Chart version bump (consistent with how other features in this repo ship, e.g. the tpl-interpolation feature bumped the chart) → Task 3. ✓
+
+**Placeholder scan:** none — all test code, the helper, and doc blocks are provided in full. Task 2 doc-insertion points are located by `grep` because exact README/values line numbers are not known in advance; the content to insert is fully specified.
+
+**Type/name consistency:** helper name `helm.whitelabelHost`, calling convention `(dict "label" <x> "ctx" $)`, and app name `wl-api` are used identically across every task and test case. Expected domains (`mycarriertms.com` for prod, `mycarrier.dev` otherwise) match `helm.domain`'s behavior and the spec table.

--- a/docs/superpowers/specs/2026-06-10-mc-environment-config-sync-design.md
+++ b/docs/superpowers/specs/2026-06-10-mc-environment-config-sync-design.md
@@ -1,0 +1,120 @@
+# Design: sync mc-environment to mycarrier-helm's configuration surface
+
+**Date:** 2026-06-10
+**Charts:** `charts/mc-environment` (primary), `charts/mycarrier-helm` (one combination test)
+**Status:** Approved (pending spec review)
+
+## Problem
+
+`mc-environment` generates one ArgoCD `ApplicationSet` per environment; each carries a `Values`
+block that is fed to the `mycarrier-helm` chart. Most sections (`applications`, `jobs`,
+`secrets`, `infrastructure`, `extraObjects`) are passed through with `toYaml`, but two blocks are
+**hand-built field-by-field** — `environment` and `global` — and the JSON schema keeps **local
+copies** of several mycarrier-helm sections. Both patterns drift from mycarrier-helm and silently
+drop or reject valid configuration.
+
+Confirmed against the current chart (HEAD):
+
+- **`environment.dependencyenv`** is read from `$env.dependencyenv`, but the documented/schema
+  input nests it under `$env.environment.dependencyenv`. Result: it renders **empty** — silently
+  dropped.
+- **`environment.domainOverride`** (and children `enabled`, `domain`) is **not emitted at all**.
+- **`environment.namespaceOverride`** is not emitted and is **absent from the schema's
+  `mycarrierEnvironmentOverride` definition**.
+- **`global`** is hand-built and only merges `global.env` per environment; per-environment
+  overrides of `global.gitbranch`, `global.dependencies`, etc. are **ignored** (e.g.
+  `example.yaml` sets a per-env `global.gitbranch`/`dependencies` that never take effect).
+- **Schema local copies drift:** the local `infrastructure` definition rejects valid mycarrier-helm
+  fields (e.g. storage `sku`, which mycarrier-helm allows), and `applications` is also a local copy
+  — so a new mycarrier-helm application field (e.g. the proposed `useRootDomain`) would fail
+  mc-environment validation until manually added.
+
+mycarrier-helm's authoritative `environment` surface: `name`, `namespaceOverride`,
+`dependencyenv`, `domainOverride{enabled,domain}`.
+
+## Solution overview
+
+Stop hand-maintaining partial copies. Pass structured blocks through, and reference
+mycarrier-helm's published schema instead of copying it.
+
+### Part 1 — `environment` block (appset.yaml): pass-through + inject name
+
+```gotemplate
+environment:
+  {{- $e := deepCopy ($env.environment | default dict) }}
+  {{- $_ := set $e "name" $env.name }}
+  {{- $e | toYaml | nindent 18 }}
+```
+
+- `name` comes from the top-level `$env.name` (canonical; also used for metadata/namespace) and is
+  injected/overwritten onto the environment block.
+- Everything else (`dependencyenv`, `namespaceOverride`, `domainOverride{...}`, and any future
+  mycarrier-helm environment field) flows through untouched.
+- Absent `$env.environment` defaults to an empty dict, yielding just `{name: <env>}`.
+
+### Part 2 — `global` block (appset.yaml): merged pass-through, preserving contracts
+
+- Deep-merge base `$.Values.global` with per-env `$env.global`
+  (`mustMergeOverwrite (deepCopy base) override`), so per-env overrides of `gitbranch`,
+  `dependencies`, `env`, etc. take effect. Fixes the silent per-env override drop.
+- Preserve the two behaviours the current template guarantees:
+  - force `appStack` to lowercase after the merge;
+  - default `correlationId` and `commitDeployed` to `""` when unset (keeps the existing
+    "empty when not set" contract / test).
+- Emit the merged map with `toYaml`.
+
+### Part 3 — schema sync (values.schema.json)
+
+- Add `namespaceOverride` to `mycarrierEnvironmentOverride` as a remote `$ref` into
+  mycarrier-helm's published schema, matching the existing per-field `$ref` pattern there.
+- Replace the drift-prone **local** `infrastructure` and `applications` definitions with remote
+  `$ref`s into mycarrier-helm's `values.schema.json` (`#/properties/infrastructure`,
+  `#/properties/applications`). This auto-syncs `sku` and every future field, including
+  `useRootDomain`.
+
+### Exclusions (per scope decision)
+
+`mc-environment` always sets `isEnvironmentDeploy: true`. Configuration that is only meaningful
+when `isEnvironmentDeploy=false` is intentionally **not** represented.
+
+## Risks / tradeoffs
+
+- **Schema pins to `main`.** Remote `$ref`s resolve against mycarrier-helm's schema on `main`, not
+  the `mycarrierChartVersion` actually deployed. This extends an existing pattern in this chart
+  (`global` already uses remote `$ref`s), so it is not a new dependency, but validation can diverge
+  from the deployed chart version if `main` moves ahead. Accepted by decision.
+- **Network at template time.** Remote `$ref` resolution assumes the schema URL is reachable when
+  Helm validates values. The existing `global` ref suggests this works, but it is **unverified** —
+  the implementation must first prove Helm actually resolves and enforces a remote `$ref` (e.g.
+  feed input that violates the remote schema and confirm validation fails). If Helm silently
+  ignores remote refs, fall back to the targeted-local-patch approach for that section.
+- **Output changes.** `global`/`environment` rendered output changes shape (merged global, new
+  environment fields). Existing snapshot tests will be re-recorded intentionally; behavioural
+  assertions are added/updated.
+
+## Testing
+
+Written test-first where practical; existing `appset_test.yaml` and snapshots kept green
+(snapshots re-recorded only where output legitimately changes).
+
+**mc-environment (`tests/appset_test.yaml`):**
+1. `environment.domainOverride{enabled,domain}` provided on input → present in the generated
+   `Values.environment.domainOverride`.
+2. `environment.namespaceOverride` and `environment.dependencyenv` → forwarded correctly (the
+   dependencyenv regression).
+3. **staticHostname + domainOverride pass-through** (explicit ask): an app with
+   `applications.<app>.staticHostname` and an env with `environment.domainOverride` →
+   the generated `Values` contains both intact.
+4. Per-env `global` override (e.g. `global.gitbranch`, `global.dependencies`) overrides the base.
+5. `correlationId`/`commitDeployed` still default to `""` when unset.
+6. A previously-rejected `infrastructure` field (storage `sku`) now passes schema validation.
+
+**mycarrier-helm (combination, proves the real outcome):**
+7. `applications.<app>.staticHostname: foo` + `environment.domainOverride{enabled: true,
+   domain: custom.com}` → VirtualService host `foo.custom.com`.
+
+## Out of scope (YAGNI)
+
+- Pinning schema `$ref`s to a release tag (decision: track `main`).
+- Reworking how `applications`/`jobs`/`secrets` are passed through (already `toYaml`).
+- Any `isEnvironmentDeploy=false`-only configuration.

--- a/docs/superpowers/specs/2026-06-10-whitelabel-host-helper-design.md
+++ b/docs/superpowers/specs/2026-06-10-whitelabel-host-helper-design.md
@@ -1,0 +1,119 @@
+# Design: `helm.whitelabelHost` template helper
+
+**Date:** 2026-06-10
+**Chart:** `charts/mycarrier-helm`
+**Status:** Approved (pending spec review)
+
+## Problem
+
+Whitelabel deployments need VirtualService hosts of the form `<label>.<domain>` in the
+long-lived environments and `<label>.<env>.<domain>` in ephemeral ones, **without hardcoding the
+domain** (it varies by environment and by `environment.domainOverride`).
+
+Values-sourced `networking.istio.hosts` entries are already run through `tpl . $` in every
+VirtualService-generation path, so template expressions in host values are evaluated against the
+root context `$`. Two facts follow:
+
+- `{{ $domain }}` does **not** work in a host value — `$domain` is a local variable inside the
+  VirtualService templates, not part of the `tpl` root context.
+- `{{ include "helm.domain" $ }}` **does** work, because named templates are globally available
+  and `helm.domain` honors `environment.domainOverride`.
+
+So an author can already write the full conditional today:
+
+```yaml
+hosts:
+  - 'estes{{ if not (has .Values.environment.name (list "prod" "preprod" "dev")) }}.{{ .Values.environment.name }}{{ end }}.{{ include "helm.domain" $ }}'
+```
+
+This is verbose and error-prone to repeat across apps/labels. The goal is a clean, reusable
+helper that encapsulates the env-infix-skip + domain logic.
+
+## Solution
+
+Add a named template `helm.whitelabelHost` that authors call inside `networking.istio.hosts`.
+
+### Usage
+
+```yaml
+networking:
+  istio:
+    hosts:
+      - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
+```
+
+### Behavior
+
+`<domain>` is the result of `helm.domain` (so `environment.domainOverride` is honored). The
+`.<env>` infix is omitted **only** for `prod`, `preprod`, and `dev`; every other environment
+(`qa`, `uat`, `feature*`, …) includes it.
+
+| `environment.name` | result |
+|---|---|
+| `prod` / `preprod` / `dev` | `estes.<domain>` |
+| `qa` | `estes.qa.<domain>` |
+| `uat` | `estes.uat.<domain>` |
+| `feature20` | `estes.feature20.<domain>` |
+| `feature20` + `domainOverride{enabled:true, domain: integratedtm.dev}` | `estes.feature20.integratedtm.dev` |
+
+### Implementation
+
+One `define` block in `charts/mycarrier-helm/templates/_helpers.tpl`, next to `helm.domain`:
+
+```gotemplate
+{{- define "helm.whitelabelHost" -}}
+{{- $label := required "whitelabelHost requires a label" .label -}}
+{{- $ctx := .ctx -}}
+{{- $env := $ctx.Values.environment.name -}}
+{{- $domain := include "helm.domain" $ctx -}}
+{{- if has $env (list "prod" "preprod" "dev") -}}
+{{- printf "%s.%s" $label $domain -}}
+{{- else -}}
+{{- printf "%s.%s.%s" $label $env $domain -}}
+{{- end -}}
+{{- end -}}
+```
+
+- **Inputs:** a dict with `label` (the whitelabel prefix, required) and `ctx` (the root `$`).
+- `ctx` gives access to `.Values.environment.name` and lets the helper call `helm.domain`.
+- `required` produces a clear render error if `label` is missing/empty.
+- The skip-set `(list "prod" "preprod" "dev")` is fixed (the long-lived shared environments).
+
+### Why no template-path changes are needed
+
+`networking.istio.hosts` entries are already passed through `tpl . $` in all five host paths
+(single-app main VS, single-app offload VS, multifrontend main VS, multifrontend offload VS,
+OffloadBase CRD). Because the helper is invoked from within a host string via `include`, it works
+in every one of those paths automatically. The only code added is the helper definition.
+
+## Testing
+
+helm-unittest, `charts/mycarrier-helm`. A dedicated suite (`tests/whitelabel_host_test.yaml`)
+asserts the rendered `spec.hosts` of a single-app VirtualService contains the expected host for an
+app whose `networking.istio.hosts` uses the helper with label `estes`:
+
+1. `environment.name: dev` → `spec.hosts` contains `estes.mycarrier.dev` (no infix).
+2. `environment.name: prod` → contains `estes.mycarriertms.com` (no infix).
+3. `environment.name: preprod` → contains `estes.mycarrier.dev` (no infix).
+4. `environment.name: feature20` → contains `estes.feature20.mycarrier.dev` (infix).
+5. `environment.name: qa` → contains `estes.qa.mycarrier.dev` (infix — pins the skip-set boundary).
+6. `environment.name: feature20` + `domainOverride{enabled:true, domain: integratedtm.dev}` →
+   contains `estes.feature20.integratedtm.dev` (override honored).
+
+(Each test sets a non-frontend deployment app with istio enabled and `offloadOperatorEnabled:
+false` so the single-app VirtualService renders; the host assertion uses `contains` on
+`spec.hosts`.)
+
+## Documentation
+
+- A short example in the istio/hosts section of `charts/mycarrier-helm/README.md`, including the
+  note that `{{ $domain }}` does not resolve in host values but `{{ include "helm.domain" $ }}`
+  and `helm.whitelabelHost` do.
+- A commented example on `networking.istio.hosts` in `charts/mycarrier-helm/values.yaml`.
+
+## Out of scope (YAGNI)
+
+- A structured `whitelabelHosts:` values field (decision: helper-in-hosts, not a new field).
+- A per-call domain-override parameter (covered by `environment.domainOverride` via `helm.domain`).
+- Configurable skip-set (fixed to prod/preprod/dev).
+- Changes to any VirtualService template (hosts are already `tpl`-evaluated).

--- a/docs/superpowers/specs/2026-06-10-whitelabel-host-helper-design.md
+++ b/docs/superpowers/specs/2026-06-10-whitelabel-host-helper-design.md
@@ -98,7 +98,14 @@ app whose `networking.istio.hosts` uses the helper with label `estes`:
 4. `environment.name: feature20` → contains `estes.feature20.mycarrier.dev` (infix).
 5. `environment.name: qa` → contains `estes.qa.mycarrier.dev` (infix — pins the skip-set boundary).
 6. `environment.name: feature20` + `domainOverride{enabled:true, domain: integratedtm.dev}` →
-   contains `estes.feature20.integratedtm.dev` (override honored).
+   contains `estes.feature20.integratedtm.dev` (override honored on the infix branch).
+7. `environment.name: dev` + `domainOverride{enabled:true, domain: integratedtm.dev}` →
+   contains `estes.integratedtm.dev` (override honored on the no-infix branch).
+8. `environment.name: dev` + `domainOverride{enabled:true, domain: integratedtm.dev}` +
+   app `staticHostname: api` + a `helm.whitelabelHost` entry with label `estes` →
+   `spec.hosts` contains BOTH `api.integratedtm.dev` (the static host) and `estes.integratedtm.dev`
+   (the whitelabel host), proving the helper coexists with `staticHostname` and both pick up the
+   overridden domain.
 
 (Each test sets a non-frontend deployment app with istio enabled and `offloadOperatorEnabled:
 false` so the single-app VirtualService renders; the host assertion uses `contains` on


### PR DESCRIPTION
This branch carries two related changes to the charts.

## 1. mc-environment — sync config surface to mycarrier-helm
Fix config that was silently dropped or wrongly rejected when generating per-environment ApplicationSets.

- **environment block**: emit the whole `$env.environment` via `toYaml` with `name` injected, so `dependencyenv`, `namespaceOverride`, and `domainOverride{enabled,domain}` reach mycarrier-helm instead of being dropped (`dependencyenv` was also read from the wrong path).
- **global block**: deep-merge per-env `global` overrides over the base and emit via `toYaml` (forcing `appStack` lowercase), so per-env `gitbranch`/`dependencies`/`env` overrides take effect.
- **schema — namespaceOverride**: add `namespaceOverride` to `mycarrierEnvironmentOverride` (remote `$ref`) so it is documented and type-validated.
- **schema — infrastructure**: repoint the drift-prone local `infrastructure` definition to mycarrier-helm's published schema (remote `$ref`); fields mycarrier-helm accepts (e.g. storage `sku`) now validate. Remote-`$ref` enforcement verified empirically.
- mycarrier-helm test characterizing `staticHostname` + `domainOverride` → `foo.custom.com`.

## 2. mycarrier-helm — `helm.whitelabelHost` template helper
A named template for whitelabel VirtualService hosts, callable from `networking.istio.hosts` (already `tpl`-evaluated, so no template-path changes):

```yaml
hosts:
  - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
```

Renders `<label>.<domain>` in `prod`/`preprod`/`dev` and `<label>.<env>.<domain>` elsewhere (`qa`, `uat`, `feature*`); the domain follows `environment.domainOverride`. Includes an 8-case test suite, `required` guards on `label`/`ctx`, README + values.yaml docs, and a chart bump `3.2.0` → `3.3.0`.

Design/plan docs under `docs/superpowers/specs/` and `docs/superpowers/plans/`.

## Known follow-ups (deferred)
- Remove the now-unreferenced `infrastructureAzure*` / `mycarrierEnvironment` schema definitions.
- Remote `$ref`s pin to `main` (established pattern in this chart), not the deployed `mycarrierChartVersion`.

## Test Plan
- [x] `helm unittest .` in `charts/mc-environment` — 8/8 pass
- [x] full `helm unittest .` in `charts/mycarrier-helm` — 55 suites / 524 tests pass (incl. new whitelabel suite 8/8)
- [x] schema rejects wrong-type `namespaceOverride` / `enableVaultCA` (remote `$ref` enforcement confirmed)
- [x] `helm.whitelabelHost` renders correctly across dev/preprod/prod/qa/feature envs and under `domainOverride`, and coexists with `staticHostname`