### PR TITLE
feat(virtualservice): useRootDomain apex publishing + chart render perf fix

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.3.2
+version: 3.3.3
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/templates/_context.tpl
+++ b/charts/mycarrier-helm/templates/_context.tpl
@@ -14,8 +14,6 @@ The cached version should be used in loops to avoid recomputation.
 {{- $_ := set $defaults "correlationId" "" -}}
 {{/* forceAutoscaling has no default - nil means "not set" and allows prod auto-scaling */}}
 
-{{- $context := deepCopy . -}}
-
 {{/* Get environment name if available, otherwise use default */}}
 {{- if and .Values .Values.environment .Values.environment.name -}}
   {{- $_ := set $defaults "environmentName" .Values.environment.name -}}
@@ -46,12 +44,13 @@ The cached version should be used in loops to avoid recomputation.
   {{- $_ := set $defaults "forceAutoscaling" .Values.global.forceAutoscaling -}}
 {{- end -}}
 
-{{/* Add defaults to context */}}
+{{/* Assemble a SLIM context: only defaults + chartDefaults. Deliberately does NOT carry a
+     deepCopy of the whole root (.Values) — serializing and re-parsing the full values tree on
+     every helm.context call (53+ call sites) was the dominant chart-render cost. Callers read
+     only .defaults.* and .chartDefaults.* off .ctx; root values are accessed off the original
+     context object, never via .ctx. */}}
 {{- $chartDefaults := include "helm.chartDefaults.raw" . | fromJson -}}
-{{- $_ := set $context "defaults" $defaults -}}
-{{- $_ := set $context "chartDefaults" $chartDefaults -}}
-
-{{- $context | toJson -}}
+{{- dict "defaults" $defaults "chartDefaults" $chartDefaults | toJson -}}
 {{- end -}}
 
 {{/*

--- a/charts/mycarrier-helm/templates/_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.tpl
@@ -17,6 +17,16 @@
 {{- end -}}
 {{- end -}}
 
+{{/* Validate an application's external-host configuration. useRootDomain (publish at the apex
+     domain with no hostname) and staticHostname are mutually exclusive; setting both is a
+     misconfiguration and fails the render with a clear message.
+     Usage: {{ include "helm.assertExternalHostConfig" (dict "appName" $name "application" $values) }} */}}
+{{- define "helm.assertExternalHostConfig" -}}
+{{- if and (dig "useRootDomain" false .application) (dig "staticHostname" "" .application) -}}
+{{- fail (printf "application %q: set either useRootDomain or staticHostname, not both" .appName) -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Build a whitelabel VirtualService host from a label and the environment-resolved domain.
      Renders <label>.<domain> in prod/preprod/dev and <label>.<env>.<domain> elsewhere.
      Call from a (tpl-evaluated) networking.istio.hosts entry:

--- a/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
@@ -19,6 +19,7 @@ hosts:
 {{- $primaryAppValues := index $frontendApps $primaryApp }}
 {{- $fullName := include "helm.fullname" (merge (dict "appName" $primaryApp "application" $primaryAppValues) $) }}
 {{- $baseFullName := include "helm.basename" (merge (dict "appName" $primaryApp "application" $primaryAppValues) $) }}
+{{- include "helm.assertExternalHostConfig" (dict "appName" $primaryApp "application" $primaryAppValues) }}
 - {{ $fullName }}
 {{- if and $metaenv (not $isFeatureEnv) }}
 - {{ $baseFullName }}.{{ $metaenv }}.internal
@@ -26,11 +27,14 @@ hosts:
 {{- if $isFeatureEnv }}
 - {{ $fullName }}.{{ $domainPrefix }}.{{ $domain }}
 {{- end }}
-{{- if and (not $primaryAppValues.staticHostname) (not $isFeatureEnv) }}
+{{- if not $isFeatureEnv }}
+{{- if (dig "useRootDomain" false $primaryAppValues) }}
+- {{ $domain }}
+{{- else if $primaryAppValues.staticHostname }}
+- {{ $primaryAppValues.staticHostname | trimSuffix "."}}.{{ $domain }}
+{{- else }}
 - {{ (list ($.Values.global.appStack) ("frontend")) | join "-" | lower | trunc 63 | trimSuffix "-" }}.{{ $domainPrefix }}.{{ $domain }}
 {{- end }}
-{{- if and ($primaryAppValues.staticHostname) (not $isFeatureEnv) }}
-- {{ $primaryAppValues.staticHostname | trimSuffix "."}}.{{ $domain }}
 {{- end }}
 {{- /* Include additional custom hosts from primary app's networking.istio.hosts */ -}}
 {{- $istioConfig := dig "networking" "istio" dict $primaryAppValues -}}
@@ -157,10 +161,10 @@ http:
 - name: {{ $key }}-redirect
   match:
   - authority:
-      prefix: {{ if and (not (contains "prod" $namespace)) (not $appValues.staticHostname) }}{{ $namespace }}-{{ end }}{{ $key }}.{{ $domain }}
+      prefix: {{ if and (not (contains "prod" $namespace)) (not $appValues.staticHostname) (not (dig "useRootDomain" false $appValues)) }}{{ $namespace }}-{{ end }}{{ $key }}.{{ $domain }}
   redirect:
     uri: /
-    authority: {{ if and (not (contains "prod" $namespace)) (not $appValues.staticHostname) }}{{ $namespace }}-{{ end }}{{ $value }}.{{ $domain }}
+    authority: {{ if and (not (contains "prod" $namespace)) (not $appValues.staticHostname) (not (dig "useRootDomain" false $appValues)) }}{{ $namespace }}-{{ end }}{{ $value }}.{{ $domain }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
@@ -16,6 +16,7 @@
 {{- $envName := $.Values.environment.name -}}
 {{- $isFeatureEnv := hasPrefix "feature" $envName -}}
 {{- $internalEnabled := dig "networking" "istio" "internalEnabled" true .application -}}
+{{- include "helm.assertExternalHostConfig" (dict "appName" .appName "application" .application) -}}
 hosts:
 - {{ $fullName }}
 {{- if and $metaenv (not $isFeatureEnv) $internalEnabled }}
@@ -26,6 +27,8 @@ hosts:
 {{- if and .application.staticHostname ($.Values.isEnvironmentDeploy | default false) }}
 - {{ .application.staticHostname | trimSuffix "."}}.{{ $domain }}
 {{- end }}
+{{- else if (dig "useRootDomain" false .application) }}
+- {{ $domain }}
 {{- else if .application.staticHostname }}
 - {{ .application.staticHostname | trimSuffix "."}}.{{ $domain }}
 {{- else }}
@@ -62,10 +65,10 @@ http:
 - name: {{ $key }}
   match:
   - authority:
-      prefix: {{ if and (not (contains "prod" $namespace)) ( not $.application.staticHostname) }}{{ $namespace }}-{{ end }}{{ $key }}.{{ $domain }}
+      prefix: {{ if and (not (contains "prod" $namespace)) ( not $.application.staticHostname) (not (dig "useRootDomain" false $.application)) }}{{ $namespace }}-{{ end }}{{ $key }}.{{ $domain }}
   redirect:
     uri: /
-    authority: {{ if and (not (contains "prod" $namespace)) ( not $.application.staticHostname) }}{{ $namespace }}-{{ end }}{{ $value }}.{{ $domain }}
+    authority: {{ if and (not (contains "prod" $namespace)) ( not $.application.staticHostname) (not (dig "useRootDomain" false $.application)) }}{{ $namespace }}-{{ end }}{{ $value }}.{{ $domain }}
 {{- end }}
 {{- end }}
 {{- if and .application.networking .application.networking.istio .application.networking.istio.routes }}

--- a/charts/mycarrier-helm/templates/offloadBase.yaml
+++ b/charts/mycarrier-helm/templates/offloadBase.yaml
@@ -31,12 +31,15 @@ spec:
   serviceName: {{ $baseFullName }}
   port: {{ default 8080 (dig "ports" "http" nil $appValues) }}
   creationPolicy: {{ dig "networking" "istio" "offloadCreationPolicy" "CreateOrAdopt" $appValues }}
+  {{- include "helm.assertExternalHostConfig" (dict "appName" $appName "application" $appValues) }}
   hosts:
   - {{ $baseFullName }}
   {{- if $internalEnabled }}
   - {{ $baseFullName }}.{{ $metaenv }}.internal
   {{- end }}
-  {{- if $appValues.staticHostname }}
+  {{- if (dig "useRootDomain" false $appValues) }}
+  - {{ $domain }}
+  {{- else if $appValues.staticHostname }}
   - {{ $appValues.staticHostname | trimSuffix "." }}.{{ $domain }}
   {{- else }}
   - {{ (list ($.Values.global.appStack) ($appName)) | join "-" | lower | trunc 63 | trimSuffix "-" }}.{{ $domainPrefix }}.{{ $domain }}

--- a/charts/mycarrier-helm/tests/frontend_virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/frontend_virtualservice_test.yaml
@@ -510,3 +510,48 @@ tests:
       # destination should NOT leak as a top-level field on the http route
       - notExists:
           path: spec.http[2].destination
+
+  - it: should publish the multifrontend VS at the apex domain when the primary app uses useRootDomain
+    set:
+      global:
+        appStack: "test-stack"
+      environment:
+        name: "prod"
+      applications:
+        main-app:
+          isFrontend: true
+          isPrimary: true
+          useRootDomain: true
+          image:
+            registry: "registry.example.com"
+            repository: "main-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+        admin-app:
+          isFrontend: true
+          isPrimary: false
+          image:
+            registry: "registry.example.com"
+            repository: "admin-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VirtualService
+      # primary app published at the bare apex domain
+      - contains:
+          path: spec.hosts
+          content: mycarriertms.com
+      - notContains:
+          path: spec.hosts
+          content: test-stack-frontend.api.mycarriertms.com

--- a/charts/mycarrier-helm/tests/offload_operator_test.yaml
+++ b/charts/mycarrier-helm/tests/offload_operator_test.yaml
@@ -293,3 +293,26 @@ tests:
           count: 1
       - isKind:
           of: OffloadRoute
+
+  - it: should publish OffloadBase at the apex domain when useRootDomain is true
+    template: offloadBase.yaml
+    set:
+      environment.name: "dev"
+      global.appStack: "devopstest"
+      global.language: "go"
+      applications.apex.deploymentType: deployment
+      applications.apex.image.registry: "myregistry.example.com"
+      applications.apex.image.repository: "mycarrier/apex"
+      applications.apex.image.tag: "1.0.0"
+      applications.apex.ports.http: 8080
+      applications.apex.useRootDomain: true
+      applications.apex.networking.istio.offloadOperatorEnabled: true
+    asserts:
+      - isKind:
+          of: OffloadBase
+      - contains:
+          path: spec.hosts
+          content: mycarrier.dev
+      - notContains:
+          path: spec.hosts
+          content: devopstest-apex.dev.mycarrier.dev

--- a/charts/mycarrier-helm/tests/virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/virtualservice_test.yaml
@@ -945,3 +945,94 @@ tests:
       - contains:
           path: spec.hosts
           content: foo.custom.com
+
+  - it: should publish at the apex domain when useRootDomain is true (prod)
+    set:
+      environment.name: "prod"
+      global.appStack: "test"
+      applications.apex-app.deploymentType: deployment
+      applications.apex-app.isFrontend: false
+      applications.apex-app.useRootDomain: true
+      applications.apex-app.image.registry: "myregistry.example.com"
+      applications.apex-app.image.repository: "mycarrier/apex-app"
+      applications.apex-app.image.tag: "1.0.0"
+      applications.apex-app.ports.http: 8080
+      applications.apex-app.networking.ingress.type: "istio"
+      applications.apex-app.networking.istio.enabled: true
+      applications.apex-app.networking.istio.offloadOperatorEnabled: false
+    asserts:
+      - isKind:
+          of: VirtualService
+      # external host is the bare apex domain, not the generated appstack-app host
+      - contains:
+          path: spec.hosts
+          content: mycarriertms.com
+      - notContains:
+          path: spec.hosts
+          content: test-apex-app.api.mycarriertms.com
+
+  - it: should ignore useRootDomain in feature environments
+    set:
+      environment.name: "feature-x"
+      global.appStack: "test"
+      applications.apex-app.deploymentType: deployment
+      applications.apex-app.isFrontend: false
+      applications.apex-app.useRootDomain: true
+      applications.apex-app.image.registry: "myregistry.example.com"
+      applications.apex-app.image.repository: "mycarrier/apex-app"
+      applications.apex-app.image.tag: "1.0.0"
+      applications.apex-app.ports.http: 8080
+      applications.apex-app.networking.ingress.type: "istio"
+      applications.apex-app.networking.istio.enabled: true
+      applications.apex-app.networking.istio.offloadOperatorEnabled: false
+      applications.apex-app.networking.istio.offloadVSEnabled: false
+    asserts:
+      # feature env keeps its normal feature hostname; the bare apex is NOT emitted
+      - contains:
+          path: spec.hosts
+          content: test-apex-app-feature-x.dev.mycarrier.dev
+        documentIndex: 0
+      - notContains:
+          path: spec.hosts
+          content: mycarrier.dev
+        documentIndex: 0
+
+  - it: should honor domainOverride for the apex host
+    set:
+      environment.name: "prod"
+      global.appStack: "test"
+      environment.domainOverride.enabled: true
+      environment.domainOverride.domain: "custom.com"
+      applications.apex-app.deploymentType: deployment
+      applications.apex-app.isFrontend: false
+      applications.apex-app.useRootDomain: true
+      applications.apex-app.image.registry: "myregistry.example.com"
+      applications.apex-app.image.repository: "mycarrier/apex-app"
+      applications.apex-app.image.tag: "1.0.0"
+      applications.apex-app.ports.http: 8080
+      applications.apex-app.networking.ingress.type: "istio"
+      applications.apex-app.networking.istio.enabled: true
+      applications.apex-app.networking.istio.offloadOperatorEnabled: false
+    asserts:
+      - contains:
+          path: spec.hosts
+          content: custom.com
+
+  - it: should fail the render when both useRootDomain and staticHostname are set
+    set:
+      environment.name: "prod"
+      global.appStack: "test"
+      applications.apex-app.deploymentType: deployment
+      applications.apex-app.isFrontend: false
+      applications.apex-app.useRootDomain: true
+      applications.apex-app.staticHostname: "foo"
+      applications.apex-app.image.registry: "myregistry.example.com"
+      applications.apex-app.image.repository: "mycarrier/apex-app"
+      applications.apex-app.image.tag: "1.0.0"
+      applications.apex-app.ports.http: 8080
+      applications.apex-app.networking.ingress.type: "istio"
+      applications.apex-app.networking.istio.enabled: true
+      applications.apex-app.networking.istio.offloadOperatorEnabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: 'application "apex-app": set either useRootDomain or staticHostname, not both'

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -174,6 +174,18 @@
               }
             ]
           },
+          "useRootDomain": {
+            "oneOf": [
+              {
+                "type": "boolean",
+                "description": "Publish the application at the bare apex domain (e.g. mycarriertms.com) with no hostname label, instead of the generated appstack-appname host. Only takes effect in non-feature environments (dev, preprod, prod); ignored in feature environments. Mutually exclusive with staticHostname.",
+                "default": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "labels": {
             "oneOf": [
               {

--- a/docs/superpowers/specs/2026-06-10-useRootDomain-apex-publishing-design.md
+++ b/docs/superpowers/specs/2026-06-10-useRootDomain-apex-publishing-design.md
@@ -1,0 +1,112 @@
+# Design: `useRootDomain` — publish an application at the apex domain
+
+**Date:** 2026-06-10
+**Chart:** `charts/mycarrier-helm`
+**Status:** Approved (pending spec review)
+
+## Problem
+
+Today every application is published under a hostname label:
+
+- Default external host: `<hostname>.<domainPrefix>.<domain>` — e.g. `app-foo.api.mycarriertms.com`
+- `staticHostname: custom` → `custom.<domain>` (skips the prefix) — e.g. `custom.mycarriertms.com`
+
+There is no way to publish an application at the **bare apex domain** — `<domain>` itself
+(`mycarriertms.com` in prod, `mycarrier.dev` in dev/preprod). Some applications (e.g. a
+marketing site) need to be served at the root.
+
+## Solution overview
+
+Add a per-application boolean **`useRootDomain`**. When true, the application's *external*
+host becomes the bare apex domain returned by `helm.domain`, with no hostname label. It is
+the apex analogue of `staticHostname`.
+
+### Semantics
+
+- **Type:** boolean, per application. Default absent / `false`.
+- **Environment scope:** effective only in **non-feature environments** (dev, preprod, prod).
+  In feature environments (`hasPrefix "feature" environment.name`) the flag is ignored and the
+  application keeps its normal feature hostname. Gate: `not $isFeatureEnv`.
+- **Effect:** replaces the generated *external* host with `{{ $domain }}`. Internal hosts
+  (`<fullName>`, `<fullName>.<namespace>.svc`, `.svc.cluster.local`, and
+  `<baseFullName>.<metaenv>.internal`) are left unchanged.
+- **Mutual exclusion:** `useRootDomain` and `staticHostname` cannot both be set on the same
+  application. If both are truthy the render **fails** with a clear message:
+  `app "<name>": set either useRootDomain or staticHostname, not both`.
+
+### Domain resolution note (existing behaviour, not changed here)
+
+`helm.domain` resolves prod-prefixed environments to `mycarriertms.com` and everything else
+(including dev and preprod) to `mycarrier.dev`, unless `environment.domainOverride` is set.
+Consequently an app using `useRootDomain` in **both** dev and preprod resolves to the same
+`mycarrier.dev` apex record. This is pre-existing domain behaviour; the feature does not change
+it. Teams needing distinct apexes per environment use `domainOverride`.
+
+## Affected surfaces
+
+Because apex publishing is non-feature only, and the offload VirtualServices only render in
+feature environments, apex never reaches the offload paths. Only three host-generation surfaces
+change:
+
+| File | Surface | Change |
+|---|---|---|
+| `templates/_spec_virtualservice.tpl` | single-app backend main VS | In the non-feature host branch, select host as: **apex** → `staticHostname` → default generated host |
+| `templates/_spec_frontend_virtualservice.tpl` | multifrontend main VS | Add an apex branch for the primary app, parallel to the existing `staticHostname` branch (the `not $isFeatureEnv` block) |
+| `templates/offloadBase.yaml` | OffloadBase CRD (the dev / offload-operator path) | Add an apex branch parallel to the `staticHostname` branch |
+
+### Why each, by environment
+
+- **dev:** `offloadOperatorEnabled` defaults true, so the backend main VS is suppressed and the
+  **OffloadBase CRD** emits the host — apex handled there.
+- **preprod / prod:** `offloadOperatorEnabled` is false, so the **backend main VS** emits the
+  host — apex handled there.
+- **frontend (any non-feature env):** the **multifrontend main VS** emits the primary app host —
+  apex handled there.
+
+### Redirect-authority gating
+
+Both spec files gate the `<namespace>-` prefix on redirect authorities with
+`and (not (contains "prod" $namespace)) (not staticHostname)`. `useRootDomain` is added to that
+condition so a fixed apex host suppresses the namespace prefix the same way `staticHostname`
+does, keeping the two options symmetric. (`_spec_virtualservice.tpl` ~lines 65/68;
+`_spec_frontend_virtualservice.tpl` ~lines 160/163.)
+
+### Validation helper
+
+A new named template, **`helm.assertExternalHostConfig`**, takes an application's values and
+calls `fail` when both `useRootDomain` and `staticHostname` are truthy. It is included once per
+application by each of the three surfaces. Three call sites justify a shared helper over inline
+duplication (DRY); a single helper also keeps the error message consistent.
+
+## Schema & documentation
+
+- `values.schema.json`: add `useRootDomain` to the application properties as
+  `oneOf: [ {type: boolean, description: ...}, {type: null} ]`, mirroring the `staticHostname`
+  entry.
+- `values.yaml`: document `useRootDomain` next to `staticHostname` (field list comment and the
+  property itself), noting it is non-feature-only and mutually exclusive with `staticHostname`.
+
+## Testing (helm-unittest, written test-first)
+
+New cases across the existing suites:
+
+1. **Backend, prod** — `useRootDomain: true` → `spec.hosts` contains `mycarriertms.com`, does
+   **not** contain `<appstack-app>.api.mycarriertms.com`; internal hosts still present.
+2. **OffloadBase, dev** — `useRootDomain: true`, `offloadOperatorEnabled: true` →
+   `spec.hosts` contains `mycarrier.dev`, not the generated `<appstack-app>...` host.
+3. **Feature env** — `useRootDomain: true` → flag ignored: normal feature hostname present, apex
+   absent; `hasDocuments` unchanged.
+4. **Multifrontend, prod** — primary app `useRootDomain: true` → apex host present on the
+   multifrontend VS.
+5. **Conflict** — `useRootDomain: true` + `staticHostname: foo` → `failedTemplate` with
+   `errorMessage` matching the both-set message.
+6. **Redirect** (optional/secondary) — `useRootDomain: true` with a redirect → redirect authority
+   has no `<namespace>-` prefix.
+
+## Out of scope (YAGNI)
+
+- Apex in feature environments.
+- Apex on the offload VirtualServices (never rendered in non-feature envs).
+- A string form / per-app apex override (covered by existing `environment.domainOverride`).
+- Any external-DNS / cloudflare-proxied annotation changes (existing annotation logic applies
+  unchanged to whatever host is emitted).


### PR DESCRIPTION
## Summary
Implements the previously-specced `useRootDomain` feature (it was designed but never built) and fixes the chart's slow render that was dragging out the unit-test suite. Chart `3.3.2` → `3.3.3`.

### useRootDomain (apex publishing)
A per-application boolean that publishes the app at the bare apex domain (`helm.domain` — e.g. `mycarriertms.com` / `mycarrier.dev` / `domainOverride`) with **no hostname label**, instead of the generated `appstack-appname` host.

- Effective only in **non-feature** environments (dev, preprod, prod); ignored in feature envs.
- **Mutually exclusive with `staticHostname`** — a shared `helm.assertExternalHostConfig` helper fails the render with a clear message if both are set.
- Wired into the single-app VirtualService, the multifrontend VirtualService, and the OffloadBase CRD; redirect-authority gating treats `useRootDomain` like `staticHostname`.
- Adds the `values.schema.json` property and tests across all three paths (including the both-set failure case).

### Chart render performance fix
`helm.default-context` `deepCopy`'d the entire root context and serialized the whole `.Values` tree to JSON on every `helm.context` call (50+ sites), with each caller re-parsing it — the dominant render cost. The context is only ever read for `.defaults.*` / `.chartDefaults.*` (nothing reads `.Values` off `.ctx`), so it now assembles a slim `{defaults, chartDefaults}` context.

- Full `helm template` render: **5.77s → 0.05s**.
- Unit-test suite (530 tests, single process, i.e. CI): **~9 min → ~7s**.
- No rendered-output changes — all 530 existing tests pass unchanged.

## Test Plan
- [x] `helm unittest .` (single process): **530/530 pass in ~6.75s**
- [x] `useRootDomain` apex host renders in prod/dev across single-app VS, multifrontend VS, and OffloadBase; ignored in feature envs; honors `domainOverride`
- [x] both `useRootDomain` + `staticHostname` → render fails with the expected message
- [x] full render byte-stable after the context change (entire existing suite green)