### PR TITLE
feat(mycarrier-helm): support additionalEndpointsBasePath passthrough

### DIFF
--- a/charts/mycarrier-helm/templates/_helpers_krakend.tpl
+++ b/charts/mycarrier-helm/templates/_helpers_krakend.tpl
@@ -316,4 +316,8 @@ cue:
 additionalEndpoints:
 {{ toYaml $krakend.additionalEndpoints | indent 2 }}
 {{- end }}
+{{- /* additionalEndpointsBasePath passthrough — overrides the operator's auto-derived base path for scoping additionalEndpoints */ -}}
+{{- if hasKey $krakend "additionalEndpointsBasePath" }}
+additionalEndpointsBasePath: {{ $krakend.additionalEndpointsBasePath | quote }}
+{{- end }}
 {{- end -}}

--- a/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
+++ b/charts/mycarrier-helm/tests/krakend_autoconfig_test.yaml
@@ -377,6 +377,7 @@ tests:
       applications.api.networking.krakend.additionalEndpoints:
         - endpoint: /liveness
           encoding: no-op
+      applications.api.networking.krakend.additionalEndpointsBasePath: /api/v1/quote
     asserts:
       - equal:
           path: spec.defaults.endpoint.timeout
@@ -399,6 +400,9 @@ tests:
       - equal:
           path: spec.additionalEndpoints[0].encoding
           value: no-op
+      - equal:
+          path: spec.additionalEndpointsBasePath
+          value: /api/v1/quote
 
   - it: should honor autoConfigNamespace override
     set:

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -1034,6 +1034,10 @@
                             "endpoint": { "type": "string" }
                           }
                         }
+                      },
+                      "additionalEndpointsBasePath": {
+                        "type": "string",
+                        "description": "Overrides the operator's auto-derived base path used to scope additionalEndpoints under the application. Must start with '/'. Mirrors KrakenDAutoConfigSpec.AdditionalEndpointsBasePath."
                       }
                     }
                   }

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -340,6 +340,7 @@ applications: {}
 #       #     name: my-cue-defs
 #       #     key: defs.cue
 #       additionalEndpoints: []           # optional; endpoints not in the OpenAPI doc (liveness/readiness). Matches KrakenDAutoConfigSpec.AdditionalEndpoints
+#       additionalEndpointsBasePath: /api/v1/quote   # optional; overrides the operator's auto-derived base path for additionalEndpoints
 #       # additionalEndpoints:
 #       #   - endpoint: /liveness         # required (must start with /)
 #       #     encoding: no-op             # optional; no-op for pass-through health checks


### PR DESCRIPTION
Follow-up to #96 (merged). Adds the chart passthrough for the operator's new `spec.additionalEndpointsBasePath` field, mirroring the existing `additionalEndpoints` passthrough. (#96's additionalEndpoints support, the chart-version-bumper vulnerability fixes, and the Helm-Release fault-tolerance fix are already on `main`; this PR is just the new field.)

## Changes

- `templates/_helpers_krakend.tpl` — `additionalEndpointsBasePath` passthrough (quoted scalar) in `helm.specs.krakendautoconfig`.
- `values.schema.json` — `additionalEndpointsBasePath` string property on the (strict) `krakend` block.
- `values.yaml` — documented example.
- `tests/krakend_autoconfig_test.yaml` — sets the field and asserts it renders into `spec.additionalEndpointsBasePath`.

## Testing

`helm unittest .` — full suite green.

Chart version is intentionally not bumped here — the Helm-Release workflow auto-bumps on merge.
