### PR TITLE
feat(mycarrier-helm): add providerConfigRef resolution for Azure Service Bus with environment-aware defaults

### DIFF
--- a/charts/mycarrier-helm/templates/_helpers.crossplane.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.crossplane.tpl
@@ -150,6 +150,36 @@ Usage: {{ $defaults := include "helm.crossplane.defaults" (dict "root" $root) | 
 {{- end -}}
 
 {{/*
+Resolve the Crossplane providerConfigRef for a Service Bus instance.
+Precedence:
+  1. per-instance .instance.providerConfigRef (if set)
+  2. explicit infrastructure.azure.defaults.providerConfigRef (if non-empty)
+  3. environment-aware default, keyed off metaEnvironment (feature-* maps to dev):
+       dev -> "default"; preprod/prod -> "baseitm"; any other env -> "default"
+Usage: {{ include "helm.azure.servicebus.providerConfigRef" (dict "instance" $sbInstance "root" $root) }}
+*/}}
+{{- define "helm.azure.servicebus.providerConfigRef" -}}
+{{- $instance := .instance -}}
+{{- $root := .root -}}
+{{- $explicitDefault := "" -}}
+{{- with $root.Values.infrastructure.azure.defaults -}}
+{{- $explicitDefault = .providerConfigRef | default "" -}}
+{{- end -}}
+{{- if $instance.providerConfigRef -}}
+{{- $instance.providerConfigRef -}}
+{{- else if $explicitDefault -}}
+{{- $explicitDefault -}}
+{{- else -}}
+{{- $metaEnv := include "helm.metaEnvironment" $root -}}
+{{- if or (eq $metaEnv "preprod") (eq $metaEnv "prod") -}}
+{{- "baseitm" -}}
+{{- else -}}
+{{- "default" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Render managementPolicies block with a default of ["Observe"].
 Usage: {{ include "helm.crossplane.managementPolicies" (dict "policies" $instance.managementPolicies) | nindent 2 }}
 */}}

--- a/charts/mycarrier-helm/templates/crossplane/azure/servicebus/servicebus.yaml
+++ b/charts/mycarrier-helm/templates/crossplane/azure/servicebus/servicebus.yaml
@@ -5,7 +5,7 @@
 {{- range $sbIndex, $sbInstance := $root.Values.infrastructure.azure.servicebus }}
 {{- $sbName := $sbInstance.name | default (include "helm.azure.servicebus.name" (dict "root" $root)) -}}
 {{- $sbNamespace := include "helm.crossplane.namespace" (dict "namespace" $sbInstance.namespace "root" $root) -}}
-{{- $sbProviderConfigRef := $sbInstance.providerConfigRef | default $defaults.providerConfigRef -}}
+{{- $sbProviderConfigRef := include "helm.azure.servicebus.providerConfigRef" (dict "instance" $sbInstance "root" $root) -}}
 {{- $sbLocation := $sbInstance.location | default $defaults.location | required "Service Bus location is required (set per-resource or infrastructure.azure.defaults.location)" -}}
 {{- if $sbInstance.managementPolicies }}
 {{- if or (has "Delete" $sbInstance.managementPolicies) (has "*" $sbInstance.managementPolicies) }}

--- a/charts/mycarrier-helm/tests/crossplane_azure_servicebus_test.yaml
+++ b/charts/mycarrier-helm/tests/crossplane_azure_servicebus_test.yaml
@@ -1386,3 +1386,177 @@ tests:
           path: spec.forProvider.forwardTo
           value: "address-integrationevents"
         documentIndex: 3
+
+  # Test 33: providerConfigRef defaults to "default" in dev (env-aware default)
+  - it: should default providerConfigRef to default in dev when none is set
+    set:
+      global.appStack: envdefdev
+      global.language: csharp
+      environment.name: dev
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          servicebus:
+            - name: "env-dev-sb"
+              location: "East US"
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "default"
+        documentIndex: 0
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "default"
+        documentIndex: 1
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "default"
+        documentIndex: 2
+
+  # Test 34: providerConfigRef defaults to "baseitm" in preprod (env-aware default)
+  - it: should default providerConfigRef to baseitm in preprod when none is set
+    set:
+      global.appStack: envdefpre
+      global.language: csharp
+      environment.name: preprod
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          servicebus:
+            - name: "env-pre-sb"
+              location: "East US"
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      # Env-aware default applies to namespace and all inherited child resources
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "baseitm"
+        documentIndex: 0
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "baseitm"
+        documentIndex: 1
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "baseitm"
+        documentIndex: 2
+
+  # Test 35: providerConfigRef defaults to "baseitm" in prod (env-aware default)
+  - it: should default providerConfigRef to baseitm in prod when none is set
+    set:
+      global.appStack: envdefprod
+      global.language: csharp
+      environment.name: prod
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          servicebus:
+            - name: "env-prod-sb"
+              location: "East US"
+              sku: "Premium"
+              capacity: 1
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "baseitm"
+        documentIndex: 0
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "baseitm"
+        documentIndex: 2
+
+  # Test 36: feature environments map to dev (default) via metaEnvironment
+  # NOTE: servicebus does not render for feature envs, so this is covered indirectly;
+  # metaEnvironment mapping is exercised by the dev/preprod/prod cases above.
+
+  # Test 37: per-instance providerConfigRef overrides the env-aware default in preprod
+  - it: should let per-instance providerConfigRef override the preprod env-aware default
+    set:
+      global.appStack: envovrpre
+      global.language: csharp
+      environment.name: preprod
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          servicebus:
+            - name: "env-ovr-sb"
+              location: "East US"
+              providerConfigRef: "custom-provider"
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "custom-provider"
+        documentIndex: 0
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "custom-provider"
+        documentIndex: 2
+
+  # Test 38: explicit infrastructure.azure.defaults.providerConfigRef overrides env-aware default in prod
+  - it: should let infrastructure.azure.defaults.providerConfigRef override the prod env-aware default
+    set:
+      global.appStack: envdefovr
+      global.language: csharp
+      environment.name: prod
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      infrastructure:
+        azure:
+          defaults:
+            providerConfigRef: "explicit-default"
+          servicebus:
+            - name: "env-defovr-sb"
+              location: "East US"
+              sku: "Premium"
+              topics:
+                - name: "orders"
+                  subscriptions:
+                    - name: "processor"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "explicit-default"
+        documentIndex: 0
+      - equal:
+          path: spec.providerConfigRef.name
+          value: "explicit-default"
+        documentIndex: 2

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -725,7 +725,7 @@ secrets:
 ## @extra infrastructure.azure Azure infrastructure resources
 ## @extra infrastructure.azure.defaults Default values shared across all Azure resources
 ## @param infrastructure.azure.defaults.location [string] Default Azure region for all resources (empty = must set per-resource)
-## @param infrastructure.azure.defaults.providerConfigRef [string] Default Crossplane ProviderConfig name
+## @param infrastructure.azure.defaults.providerConfigRef [string] Default Crossplane ProviderConfig name (empty = auto: resourceGroup/storage use "default"; servicebus is environment-aware — dev="default", preprod/prod="baseitm")
 ## @param infrastructure.azure.resourceGroup [array] Azure Resource Group configurations
 ## @extra infrastructure.azure.storage Azure Storage configuration
 ## @param infrastructure.azure.storage.accounts [array] Azure storage account configurations
@@ -738,7 +738,10 @@ infrastructure:
     # Per-resource values take precedence over these defaults.
     defaults:
       location: ""                  # Default Azure region (e.g., "East US"). Empty = must set per-resource.
-      providerConfigRef: "default"  # Default Crossplane ProviderConfig name
+      providerConfigRef: ""         # Default Crossplane ProviderConfig name. Empty = auto:
+                                    #   - resourceGroup & storage fall back to "default"
+                                    #   - servicebus is environment-aware: dev="default", preprod/prod="baseitm"
+                                    # Set a non-empty value here to force one ProviderConfig for all resources.
 
     # Azure Resource Group configurations
     resourceGroup: []
@@ -822,7 +825,9 @@ infrastructure:
       #                                                    # Examples: inf-dev-servicebus, inf-preprod-servicebus, inf-prod-servicebus
       #   location: "East US"                             # Required: Azure region (or set infrastructure.azure.defaults.location)
       #   sku: "Standard"                                 # Optional: Basic, Standard, or Premium (default: "Standard")
-      #   providerConfigRef: "default"                    # Optional: Crossplane ProviderConfig name (default: infrastructure.azure.defaults.providerConfigRef, or "default")
+      #   providerConfigRef: "default"                    # Optional: Crossplane ProviderConfig name
+      #                                                    # Default: infrastructure.azure.defaults.providerConfigRef if set, else environment-aware:
+      #                                                    #   dev="default", preprod/prod="baseitm" (feature-* maps to dev)
       #                                                    # Inherited by all child resources (topics, subscriptions, rules)
       #   resourceGroupName: "rg-app-dev"                 # Optional: Resource group name (default: inf-{env}, matching default RG name)
       #


### PR DESCRIPTION
# feat(mycarrier-helm): environment-aware `providerConfigRef` default for Azure Service Bus

## Summary

Adds environment-aware defaulting for the Crossplane `providerConfigRef` on
`infrastructure.azure.servicebus` declarations. When a declaration does **not**
specify a provider, it now resolves based on the environment instead of always
falling back to `default`:

| Environment (`metaEnvironment`) | Default `providerConfigRef` |
| ------------------------------- | --------------------------- |
| `dev` (and `feature-*` → `dev`) | `default`                   |
| `preprod`                       | `baseitm`                   |
| `prod`                          | `baseitm`                   |
| any other env                   | `default` (safe fallback)   |

The change is **scoped to Service Bus only**. `resourceGroup` and
`storage/claim`, which share the same `helm.crossplane.defaults` helper, keep
their existing `default` behavior.

## Motivation

`preprod` and `prod` Service Bus resources need to reconcile through the
`baseitm` Crossplane ProviderConfig, while `dev` uses `default`. Previously
every environment defaulted to `default`, forcing each declaration to pin
`providerConfigRef` explicitly per environment. This makes the correct provider
the default, so declarations can omit it and get the right one automatically.

## Resolution precedence (Service Bus)

1. **Per-instance** `servicebus[].providerConfigRef` — wins if set _(unchanged)_.
2. **Explicit** `infrastructure.azure.defaults.providerConfigRef` — wins if set
   to a non-empty value _(unchanged)_.
3. **Environment-aware default** (new) — used only when neither of the above is
   set, keyed off `metaEnvironment` (so `feature-*` maps to `dev`).

## Implementation notes

- New helper `helm.azure.servicebus.providerConfigRef` in
  `_helpers.crossplane.tpl` encapsulates the precedence above.
- `servicebus.yaml` now calls the helper for `providerConfigRef`
  (`helm.crossplane.defaults` is still used for `location`).
- The shipped `values.yaml` seed `infrastructure.azure.defaults.providerConfigRef`
  changed from `"default"` to `""` (empty = "auto"). This is **invisible to
  `resourceGroup` and `storage/claim`**: the shared helper still falls back to
  its own internal `"default"` when the seed is empty, so those two templates
  render identically to before. Only Service Bus reads the env-aware path.
- **Offload / feature environments: no change.** The template's existing
  `not (hasPrefix "feature" ...)` guard already excludes Crossplane resources
  from the offload render path.

## Files changed

| File | Change |
| ---- | ------ |
| `templates/_helpers.crossplane.tpl` | New `helm.azure.servicebus.providerConfigRef` helper (+30) |
| `templates/crossplane/azure/servicebus/servicebus.yaml` | Resolve `providerConfigRef` via the new helper |
| `values.yaml` | Seed `defaults.providerConfigRef` → `""`; updated `@param` + example docs |
| `tests/crossplane_azure_servicebus_test.yaml` | 5 new cases (+174) |

## Testing

- **Full chart suite: `543 passed / 543 total`** (`helm unittest .`), including 5
  new Service Bus cases and no regression in the `resourcegroup` / `storage`
  suites that share the seed.
- New cases cover: `dev`→`default`, `preprod`→`baseitm`, `prod`→`baseitm`,
  per-instance override in `preprod`, and explicit-default override in `prod`.
- **Real `helm template` render** verified across environments (declaration
  omitting `providerConfigRef`): `dev`→`default`, `preprod`/`prod`→`baseitm`;
  explicit values still win at every level.

## Backward compatibility

- **`dev` is unchanged** — still resolves to `default`.
- Declarations that explicitly set `providerConfigRef` (per-instance or via
  `infrastructure.azure.defaults.providerConfigRef`) are unaffected.
- **Behavior change only for `preprod`/`prod` declarations that omit
  `providerConfigRef`**: they now resolve to `baseitm` instead of `default`.

## Upgrade / usage note

To benefit from the env-aware default, **omit `providerConfigRef`** on Service
Bus declarations. A declaration that still hardcodes `providerConfigRef: "default"`
will keep resolving to `default` in `preprod`/`prod` (per-instance always wins).
