### PR TITLE
feat(mycarrier-helm): v3.5.0 secure defaults — drop-caps + readiness/liveness probes on (DEVOPS-176 Workstream B)

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.4.0
+version: 3.5.0
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -16,6 +16,15 @@ securityContext:
   runAsNonRoot: true
   readOnlyRootFilesystem: {{ if and .application .application.securityContext .application.securityContext.readOnlyRootFilesystem }}true{{ else }}false{{ end }}
   allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+{{- if .application }}
+{{- with (dig "securityContext" "addCapabilities" (list) .application) }}
+    add:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/mycarrier-helm/templates/_spec_deployment.tpl
+++ b/charts/mycarrier-helm/templates/_spec_deployment.tpl
@@ -122,7 +122,7 @@ template:
         {{ include "helm.defaultLivenessProbe" . | indent 8 | trim }}
         {{- end }}
         {{- end }}
-        {{- if dig "probes" "enableReadiness" false .application }}
+        {{- if dig "probes" "enableReadiness" true .application }}
         {{- if and (dig "probes" false .application) (dig "readinessProbe" false .application.probes) }}
         readinessProbe:
           {{ toYaml .application.probes.readinessProbe | indent 10 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_rollout.tpl
+++ b/charts/mycarrier-helm/templates/_spec_rollout.tpl
@@ -124,24 +124,24 @@ template:
             protocol: TCP
           {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableLiveness") (.application.probes.enableLiveness) }}
-        {{- if .application.probes.livenessProbe }}
+        {{- if dig "probes" "enableLiveness" true .application }}
+        {{- if and (dig "probes" false .application) (dig "livenessProbe" false .application.probes) }}
         livenessProbe:
           {{ toYaml .application.probes.livenessProbe | indent 10 | trim }}
         {{- else }}
         {{ include "helm.defaultLivenessProbe" . | indent 8 | trim }}
         {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableReadiness") (.application.probes.enableReadiness) }}
-        {{- if .application.probes.readinessProbe }}
+        {{- if dig "probes" "enableReadiness" true .application }}
+        {{- if and (dig "probes" false .application) (dig "readinessProbe" false .application.probes) }}
         readinessProbe:
           {{ toYaml .application.probes.readinessProbe | indent 10 | trim }}
         {{- else }}
         {{ include "helm.defaultReadinessProbe" . | indent 8 | trim }}
         {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableStartup") (.application.probes.enableStartup) }}
-        {{- if .application.probes.startupProbe }}
+        {{- if dig "probes" "enableStartup" true .application }}
+        {{- if and (dig "probes" false .application) (dig "startupProbe" false .application.probes) }}
         startupProbe:
           {{ toYaml .application.probes.startupProbe | indent 10 | trim }}
         {{- else }}

--- a/charts/mycarrier-helm/templates/_spec_statefulset.tpl
+++ b/charts/mycarrier-helm/templates/_spec_statefulset.tpl
@@ -87,24 +87,24 @@ template:
             containerPort: {{ $value }}
           {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableLiveness") (.application.probes.enableLiveness)}}
-        {{- if .application.probes.livenessProbe }}
+        {{- if dig "probes" "enableLiveness" true .application }}
+        {{- if and (dig "probes" false .application) (dig "livenessProbe" false .application.probes) }}
         livenessProbe:
           {{ toYaml .application.probes.livenessProbe | indent 10 | trim }}
         {{- else }}
         {{ include "helm.defaultLivenessProbe" . | indent 8 | trim }}
         {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableReadiness") (.application.probes.enableReadiness)}}
-        {{- if .application.probes.readinessProbe }}
+        {{- if dig "probes" "enableReadiness" true .application }}
+        {{- if and (dig "probes" false .application) (dig "readinessProbe" false .application.probes) }}
         readinessProbe:
           {{ toYaml .application.probes.readinessProbe | indent 10 | trim }}
         {{- else }}
         {{ include "helm.defaultReadinessProbe" . | indent 8 | trim }}
         {{- end }}
         {{- end }}
-        {{- if and .application.probes (hasKey .application.probes "enableStartup") (.application.probes.enableStartup)}}
-        {{- if .application.probes.startupProbe }}
+        {{- if dig "probes" "enableStartup" true .application }}
+        {{- if and (dig "probes" false .application) (dig "startupProbe" false .application.probes) }}
         startupProbe:
           {{ toYaml .application.probes.startupProbe | indent 10 | trim }}
         {{- else }}

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -79,3 +79,75 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: false
+
+  - it: should drop ALL capabilities by default with no add list
+    set:
+      environment.name: "dev"
+      applications.no-caps-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "no-caps-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+
+  - it: should add back a single capability via securityContext.addCapabilities
+    set:
+      environment.name: "dev"
+      applications.single-add-cap-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "single-add-cap-app"
+          tag: "1.0.0"
+        securityContext:
+          addCapabilities:
+            - NET_BIND_SERVICE
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value:
+            - NET_BIND_SERVICE
+
+  - it: should add back multiple capabilities via securityContext.addCapabilities
+    set:
+      environment.name: "dev"
+      applications.multi-add-cap-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "multi-add-cap-app"
+          tag: "1.0.0"
+        securityContext:
+          addCapabilities:
+            - NET_BIND_SERVICE
+            - SYS_TIME
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value:
+            - NET_BIND_SERVICE
+            - SYS_TIME

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -108,7 +108,8 @@ deployment: deployment
 ## **Basic Settings**: enableDebugMode, isFrontend, language, forceOffload, staticHostname, deploymentType, version, replicas
 ## **Container**: image.registry, image.repository, image.tag, pullPolicy, pullSecret
 ## **Resources**: resources.requests.cpu/memory, resources.limits.cpu/memory
-## **Health Probes**: probes.enableLiveness, probes.enableReadiness, probes.enableStartup, custom probe configurations
+## **Health Probes**: probes.enableLiveness, probes.enableReadiness, probes.enableStartup (all default true; set to false to disable), custom probe configurations
+## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back)
 ## **Service**: service.type, service.ports, service.annotations, service.timeout, service.retryOn
 ## **Networking**: networking.ingress.type, networking.istio.enabled/hosts/routes/corsPolicy/allowedEndpoints
 ## **Autoscaling**: HPA (autoscaling.minReplicas/maxReplicas/targetCPU/targetMemory), VPA (vpa.enabled/updateMode/resources)
@@ -194,9 +195,13 @@ applications: {}
 #   
 #   securityContext:
 #     readOnlyRootFilesystem: false
-#   
+#     # All capabilities are dropped by default (drop: [ALL]). List specific
+#     # capabilities here to add them back for this application only:
+#     # addCapabilities:
+#     #   - NET_BIND_SERVICE
+#
 #   # ----------------------------------------------------------------------------
-#   # Health Probes
+#   # Health Probes (all default true; set to false to disable)
 #   # ----------------------------------------------------------------------------
 #   probes:
 #     enableLiveness: true


### PR DESCRIPTION
## Summary

Three secure-by-default, per-app-overridable changes to `charts/mycarrier-helm`, bumped to `v3.5.0`:

1. **Drop all Linux capabilities by default** — `_podsecurity.tpl` (`helm.containerSecurityContext`) now adds `capabilities.drop: [ALL]` to every container securityContext. Services that need a specific capability back can opt in via `securityContext.addCapabilities: [...]` in their application values (satisfies `disallow-add-capabilities` for services that don't opt in).
2. **Deployment readiness probe on by default** — `_spec_deployment.tpl`: `probes.enableReadiness` now defaults `true` (was `false`), matching the existing default-true pattern already used for liveness/startup. Still overridable per app via `probes.enableReadiness: false`.
3. **StatefulSet + Rollout probes on by default** — `_spec_statefulset.tpl` / `_spec_rollout.tpl`: liveness/readiness/startup probes were previously fully opt-in (required explicit `enableX: true`); now default to `true` via the same `dig "probes" "enableX" true .application` pattern the Deployment template already used. All three remain overridable per app (`probes.enableLiveness/enableReadiness/enableStartup: false`).

All three changes are **per-application overridable** via `values.yaml` — no service is forced into new behavior it can't opt out of.

Publishing chart `3.5.0` does **not** deploy anywhere by itself — nothing consumes it until the `workflow-dev` chart-version pin is bumped, which is a separate, explicitly gated rollout step (not part of this PR; `workflow-dev`/`workflow-core` were not touched here).

Seccomp profile enforcement is intentionally deferred to a follow-up — out of scope for this change.

## Validation

- `helm lint charts/mycarrier-helm` — pass.
- `helm unittest charts/mycarrier-helm` (existing suite) — 570/570 tests pass. This caught and led to a fix for a regression where `.application` is `nil` in the Job/CronJob template context (capabilities dig now guarded with `{{- if .application }}`, matching the existing guard pattern used for `readOnlyRootFilesystem`).
- **Render-diff**: rendered the chart before/after these changes using MC.Address-derived values (all 9 real Deployment apps) plus synthetic StatefulSet/Rollout/override-capability test cases. The diff shows *only*:
  - added `readinessProbe` (tcpSocket) on Deployment containers that didn't already have one (11 additions: 9 Deployment apps + StatefulSet + Rollout example)
  - added `livenessProbe`/`startupProbe` on the StatefulSet/Rollout examples (2 each)
  - added `capabilities: {drop: [ALL]}` on every container (12 additions)
  - added `capabilities.add: [NET_BIND_SERVICE]` on the one synthetic app that set `securityContext.addCapabilities` (confirming override works)
  - `targetRevision: 3.4.0 → 3.5.0` in the embedded ArgoCD Application example (expected consequence of the Chart.yaml bump)
  - No other fields changed, reordered, or broken.

## Test plan

- [x] `helm lint charts/mycarrier-helm` passes
- [x] `helm unittest charts/mycarrier-helm` — 570/570 pass
- [x] Render-diff (old 3.4.0 vs new 3.5.0 templates) reviewed — only the three intended changes present
- [ ] Reviewer sign-off
- [ ] Separate, explicitly-gated `workflow-dev` chart-version pin bump before this reaches any live deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)