### PR TITLE
feat(mycarrier-helm): configurable ingress gateway for VirtualServices

### DIFF
--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -405,8 +405,7 @@ networking:
         paths:
           - path: "/"
             pathType: "Prefix"
-    gateways:
-      - "istio-system/ingressgateway"
+    gateway: "istio-system/default"        # Ingress gateway (namespace/name); e.g. istio-system/authenticated for the authenticated gateway
     redirects: {}
     routes: {}
     responseHeaders: {}
@@ -421,6 +420,8 @@ networking:
         - "Content-Type"
       maxAge: "24h"
 ```
+
+The `mesh` gateway is always included in rendered VirtualServices; `gateway` only replaces the ingress-gateway entry and defaults to `istio-system/default` when unset. Workload resources (Deployment/StatefulSet/Rollout) and their pods carry the resolved designation in a `mycarrier.io/gateway` annotation for troubleshooting, unless istio is disabled for the application.
 
 #### Whitelabel hosts
 

--- a/charts/mycarrier-helm/templates/_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_helpers.tpl
@@ -208,6 +208,22 @@ sidecar.istio.io/inject: 'true'
 {{- end -}}
 {{- end -}}
 
+{{/*
+Ingress gateway annotation for workload resources and their pod templates.
+Context: an app context (dict containing .application).
+Emits the resolved gateway designation for troubleshooting; omitted when istio
+is disabled for the application (networking.istio.enabled false, istioDisabled,
+or service.istioDisabled).
+*/}}
+{{- define "helm.annotations.gateway" -}}
+{{- $istioEnabled := dig "networking" "istio" "enabled" true .application -}}
+{{- $appIstioDisabled := dig "istioDisabled" false .application -}}
+{{- $serviceIstioDisabled := dig "service" "istioDisabled" false .application -}}
+{{- if and $istioEnabled (not $appIstioDisabled) (not $serviceIstioDisabled) -}}
+mycarrier.io/gateway: {{ include "helm.istio.gateway" .application }}
+{{- end -}}
+{{- end -}}
+
 {{- define "helm.annotations.virtualservice" -}}
 {{- /* Get cloudflareProxied from application's networking.istio.cloudflareProxied (default: true) */ -}}
 {{- $cloudflareProxied := true -}}

--- a/charts/mycarrier-helm/templates/_spec_deployment.tpl
+++ b/charts/mycarrier-helm/templates/_spec_deployment.tpl
@@ -67,6 +67,7 @@ template:
     annotations:
       {{ include "helm.annotations.vault" $ | indent 6 | trim }}
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
+      {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
       {{ with .application.annotations }}
       {{ toYaml . |  indent 6 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_frontend_virtualservice.tpl
@@ -45,9 +45,8 @@ hosts:
 {{- end -}}
 {{- end }}
 
-gateways:
-- mesh
-- istio-system/default
+{{- $gatewaysAppValues := index $frontendApps $primaryApp }}
+{{ include "helm.virtualservice.gateways" $gatewaysAppValues | trim }}
 
 http:
 {{- if not $isFeatureEnv }}
@@ -318,9 +317,7 @@ hosts:
 - {{ tpl . $ }}
 {{- end -}}
 {{- end }}
-gateways:
-- mesh
-- istio-system/default
+{{ include "helm.virtualservice.gateways" $primaryAppValues | trim }}
 http:
 {{/* Custom routes (networking.istio.routes) for any frontend app - env-gated, most specific first.
      The offload VS also binds the shared frontend host, so every route must match the environment

--- a/charts/mycarrier-helm/templates/_spec_rollout.tpl
+++ b/charts/mycarrier-helm/templates/_spec_rollout.tpl
@@ -77,6 +77,7 @@ template:
     annotations:
       {{ include "helm.annotations.vault" $ | indent 6 | trim }}
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
+      {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
       {{ with .application.annotations }}
       {{ toYaml . | indent 6 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_statefulset.tpl
+++ b/charts/mycarrier-helm/templates/_spec_statefulset.tpl
@@ -29,6 +29,7 @@ template:
     annotations:
       {{ include "helm.annotations.vault" $ | indent 6 | trim }}
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
+      {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
       {{- with .application.annotations }}
       {{ toYaml . |  indent 6 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
+++ b/charts/mycarrier-helm/templates/_spec_virtualservice.tpl
@@ -41,9 +41,7 @@ hosts:
 - {{ tpl . $ }}
 {{- end }}
 {{- end }}
-gateways:
-- mesh
-- istio-system/default
+{{ include "helm.virtualservice.gateways" .application | trim }}
 http:
 {{/* First route: explicit header match - routes traffic with environment header */}}
 - name: {{ $fullName }}

--- a/charts/mycarrier-helm/templates/_virtualservice_helpers.tpl
+++ b/charts/mycarrier-helm/templates/_virtualservice_helpers.tpl
@@ -106,6 +106,26 @@ Centralized HTTP rule name and match rendering for all endpoint kinds
 {{- end }}
 
 {{/*
+Resolves the ingress gateway designation (namespace/name) for an application.
+Context: the application values dict.
+Returns networking.istio.gateway, defaulting to istio-system/default when unset or empty.
+*/}}
+{{- define "helm.istio.gateway" -}}
+{{- (dig "networking" "istio" "gateway" "" .) | default "istio-system/default" -}}
+{{- end -}}
+
+{{/*
+Renders the gateways block for VirtualService-style specs.
+Context: the application values dict.
+Always emits mesh first, then the resolved ingress gateway.
+*/}}
+{{- define "helm.virtualservice.gateways" -}}
+gateways:
+- mesh
+- {{ include "helm.istio.gateway" . }}
+{{- end -}}
+
+{{/*
 Helper template to generate VirtualService HTTP rules for language-specific and user-defined endpoints
 This template generates the complete HTTP rules as strings to avoid duplication
 */}}

--- a/charts/mycarrier-helm/templates/deployment.yaml
+++ b/charts/mycarrier-helm/templates/deployment.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- else }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=true
     {{- end }}
+    {{ include "helm.annotations.gateway" $appContext | indent 4 | trim }}
 spec:
   {{ include "helm.specs.deployment" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/templates/offloadBase.yaml
+++ b/charts/mycarrier-helm/templates/offloadBase.yaml
@@ -49,9 +49,7 @@ spec:
   - {{ tpl . $ }}
   {{- end }}
   {{- end }}
-  gateways:
-  - mesh
-  - istio-system/default
+  {{ include "helm.virtualservice.gateways" $appValues | indent 2 | trim }}
   {{- if dig "networking" "istio" "offloadVirtualServiceAnnotations" nil $appValues }}
   virtualServiceAnnotations:
     {{- toYaml $appValues.networking.istio.offloadVirtualServiceAnnotations | nindent 4 }}

--- a/charts/mycarrier-helm/templates/rollout.yaml
+++ b/charts/mycarrier-helm/templates/rollout.yaml
@@ -18,6 +18,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "10"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=true
+    {{ include "helm.annotations.gateway" $appContext | indent 4 | trim }}
 spec:
   {{ include "helm.specs.rollout" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/templates/statefulset.yaml
+++ b/charts/mycarrier-helm/templates/statefulset.yaml
@@ -23,6 +23,7 @@ metadata:
     {{- else }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=true
     {{- end }}
+    {{ include "helm.annotations.gateway" $appContext | indent 4 | trim }}
 spec:
   {{ include "helm.specs.statefulset" $appContext | indent 2 | trim }}
 ---

--- a/charts/mycarrier-helm/templates/virtualService.yaml
+++ b/charts/mycarrier-helm/templates/virtualService.yaml
@@ -64,9 +64,7 @@ spec:
   - {{ tpl . $ }}
   {{- end -}}
   {{- end }}
-  gateways:
-  - mesh
-  - istio-system/default
+  {{ include "helm.virtualservice.gateways" $appValues | indent 2 | trim }}
   http:
   {{- /* Custom routes (networking.istio.routes) - most specific first, before the catch-all */ -}}
   {{- if and (hasKey $istioConfig "routes") $istioConfig.routes }}

--- a/charts/mycarrier-helm/tests/deployment_test.yaml
+++ b/charts/mycarrier-helm/tests/deployment_test.yaml
@@ -22,6 +22,66 @@ tests:
       - isNotNullOrEmpty:
           path: spec.template
 
+  - it: should annotate deployment with the default gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+
+  - it: should annotate deployment with a custom gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+
+  - it: should not annotate deployment with a gateway when istio is disabled
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.networking.istio.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: metadata.annotations["mycarrier.io/gateway"]
+      - notExists:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+
   - it: should not create deployment when deploymentType is not deployment
     set:
       environment.name: "dev"

--- a/charts/mycarrier-helm/tests/frontend_virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/frontend_virtualservice_test.yaml
@@ -103,6 +103,97 @@ tests:
           path: spec.hosts
           content: test-stack-main-app.dev.internal
 
+  - it: should use primary apps custom gateway from networking.istio.gateway
+    set:
+      global:
+        appStack: "test-stack"
+      environment:
+        name: "dev"
+      applications:
+        main-app:
+          isFrontend: true
+          isPrimary: true
+          image:
+            registry: "registry.example.com"
+            repository: "main-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+              gateway: istio-system/authenticated
+        admin-app:
+          isFrontend: true
+          isPrimary: false
+          image:
+            registry: "registry.example.com"
+            repository: "admin-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VirtualService
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+
+  - it: should apply primary apps custom gateway to the offload VS in feature environments
+    set:
+      global:
+        appStack: "test-stack"
+      environment:
+        name: "feature-abc"
+      applications:
+        main-app:
+          isFrontend: true
+          isPrimary: true
+          image:
+            registry: "registry.example.com"
+            repository: "main-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+              gateway: istio-system/authenticated
+        admin-app:
+          isFrontend: true
+          isPrimary: false
+          image:
+            registry: "registry.example.com"
+            repository: "admin-app"
+            tag: "1.0.0"
+          ports:
+            http: 4200
+          networking:
+            istio:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+        documentIndex: 0
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+        documentIndex: 1
+
   - it: should omit internal host for feature frontend environments
     set:
       global:

--- a/charts/mycarrier-helm/tests/offload_operator_test.yaml
+++ b/charts/mycarrier-helm/tests/offload_operator_test.yaml
@@ -113,6 +113,30 @@ tests:
           path: spec.responseHeaders["X-Frame-Options"]
           value: "DENY"
 
+  - it: should use custom gateway from networking.istio.gateway in OffloadBase
+    template: offloadBase.yaml
+    set:
+      environment.name: "dev"
+      global.appStack: "devopstest"
+      global.language: "go"
+      applications.routetester.deploymentType: deployment
+      applications.routetester.image.registry: "myregistry.example.com"
+      applications.routetester.image.repository: "mycarrier/routetester"
+      applications.routetester.image.tag: "1.0.0"
+      applications.routetester.ports.http: 8080
+      applications.routetester.networking.istio.offloadOperatorEnabled: true
+      applications.routetester.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: OffloadBase
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+
   - it: should interpolate tpl expressions in OffloadBase custom hosts
     template: offloadBase.yaml
     set:

--- a/charts/mycarrier-helm/tests/rollout_test.yaml
+++ b/charts/mycarrier-helm/tests/rollout_test.yaml
@@ -53,6 +53,75 @@ tests:
       - exists:
           path: spec.strategy.blueGreen
 
+  - it: should annotate rollout with the default gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: rollout
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.updateStrategy.type: "RollingUpdate"
+      applications.test-app-api.updateStrategy.canary.steps:
+        - setWeight: 100
+    asserts:
+      - isKind:
+          of: Rollout
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+
+  - it: should annotate rollout with a custom gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: rollout
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.updateStrategy.type: "RollingUpdate"
+      applications.test-app-api.updateStrategy.canary.steps:
+        - setWeight: 100
+      applications.test-app-api.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - isKind:
+          of: Rollout
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+
+  - it: should not annotate rollout with a gateway when istio is disabled
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: rollout
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.updateStrategy.type: "RollingUpdate"
+      applications.test-app-api.updateStrategy.canary.steps:
+        - setWeight: 100
+      applications.test-app-api.service.istioDisabled: true
+    asserts:
+      - isKind:
+          of: Rollout
+      - notExists:
+          path: metadata.annotations["mycarrier.io/gateway"]
+      - notExists:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+
   - it: should not create rollout when deploymentType is not rollout
     set:
       environment.name: "dev"

--- a/charts/mycarrier-helm/tests/statefulset_test.yaml
+++ b/charts/mycarrier-helm/tests/statefulset_test.yaml
@@ -47,6 +47,63 @@ tests:
           path: metadata.namespace
           value: prod
 
+  - it: should annotate statefulset with the default gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: statefulset
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/default
+
+  - it: should annotate statefulset with a custom gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: statefulset
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+      - equal:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+          value: istio-system/authenticated
+
+  - it: should not annotate statefulset with a gateway when istio is disabled
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: statefulset
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.istioDisabled: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: metadata.annotations["mycarrier.io/gateway"]
+      - notExists:
+          path: spec.template.metadata.annotations["mycarrier.io/gateway"]
+
   - it: should configure volume mounts when volumes are specified
     set:
       environment.name: "dev"

--- a/charts/mycarrier-helm/tests/virtualservice_test.yaml
+++ b/charts/mycarrier-helm/tests/virtualservice_test.yaml
@@ -152,6 +152,53 @@ tests:
           value: app-test-app-api-feature-test.dev.mycarrier.dev
         documentIndex: 1
 
+  - it: should use custom gateway from networking.istio.gateway
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.networking.istio.offloadOperatorEnabled: false
+      applications.test-app-api.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - isKind:
+          of: VirtualService
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+
+  - it: should apply custom gateway to the offload virtual service in feature environments
+    set:
+      environment.name: "feature-test"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.networking.istio.offloadOperatorEnabled: false
+      applications.test-app-api.networking.istio.gateway: istio-system/authenticated
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+        documentIndex: 0
+      - equal:
+          path: spec.gateways
+          value:
+            - mesh
+            - istio-system/authenticated
+        documentIndex: 1
+
   - it: should include staticHostname in feature environment when isEnvironmentDeploy is true
     set:
       environment.name: "feature-test"

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -769,6 +769,11 @@
                               "type": "string"
                             }
                           },
+                          "gateway": {
+                            "type": "string",
+                            "description": "Ingress gateway designation (namespace/name) that replaces istio-system/default. The mesh gateway is always included.",
+                            "default": "istio-system/default"
+                          },
                           "redirects": {
                             "type": "object",
                             "additionalProperties": {

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -266,6 +266,7 @@ applications: {}
 #       #     - '{{ include "helm.whitelabelHost" (dict "label" "estes" "ctx" $) }}'
 #       # Renders estes.<domain> in prod/preprod/dev and estes.<env>.<domain> elsewhere.
 #       hosts: []
+#       gateway: istio-system/default  # Ingress gateway (namespace/name) bound in addition to mesh, which is always included (default: istio-system/default)
 #       redirects: {}
 #       routes: {}  # Custom routes; destination defaults to the app's service. Override with 'destination' field per route.
 #       # routes:


### PR DESCRIPTION
## Summary

Adds `networking.istio.gateway` (per application, string, default `istio-system/default`) so an app can be subscribed to an alternate ingress gateway — e.g. the authenticated gateway:

```yaml
applications:
  myapp:
    networking:
      istio:
        gateway: istio-system/authenticated
```

The `mesh` gateway is always rendered first; only the ingress-gateway entry is replaced, so in-mesh and feature-header routing cannot be broken by configuration.

## Changes

- New `helm.istio.gateway` helper resolves the designation once; `helm.virtualservice.gateways` renders the block from it
- Applied at every gateway render site so no path is left on the default gateway when an app moves: main VirtualService, feature-env offload VS, multifrontend VS + its offload variant, and the OffloadBase CRD
- New `mycarrier.io/gateway` annotation on Deployments/StatefulSets/Rollouts and their pod templates (verbatim designation, for troubleshooting); omitted when istio is disabled for the app via `networking.istio.enabled`, `istioDisabled`, or `service.istioDisabled`
- Schema, `values.yaml` example, and README updated — the README previously documented a `gateways:` list key that was never implemented

## Notes

- The pod-template annotation causes one rolling restart of workloads on the next chart upgrade
- `Chart.yaml` untouched (CI handles the version bump)

## Testing

- 14 new helm-unittest cases: full-list `spec.gateways` equality for default/override on all VS variants and OffloadBase; annotation default/override/absent-when-disabled per workload kind (each disabled test exercises a different disable flag)
- Full suite: 587/587 tests pass across 59 suites; `helm lint` clean