### PR TITLE
feat(mycarrier-helm): add Auth_StrivacityIdentityStore_EnvironmentMapping secret mapping

### DIFF
--- a/charts/mycarrier-helm/templates/_lang.tpl
+++ b/charts/mycarrier-helm/templates/_lang.tpl
@@ -15,6 +15,8 @@
   value: "Development"
 - name: Auth_Environment
   value: "Development"
+- name: Auth_StrivacityIdentityStore_EnvironmentMapping
+  value: "vault:secrets/data/dev/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value"
 {{- end }}
 {{- if eq $metaenv "preprod" }}
 - name: Auth_CustomerService_BaseUrl
@@ -31,6 +33,8 @@
   value: "PreProd"
 - name: Auth_Environment
   value: "PreProd"
+- name: Auth_StrivacityIdentityStore_EnvironmentMapping
+  value: "vault:secrets/data/preprod/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value"
 {{- end }}
 {{- if eq $metaenv "prod" }}
 - name: Auth_CustomerService_BaseUrl
@@ -49,6 +53,8 @@
   value: "Production"
 - name: production_tenants
   value: "vault:secrets/data/prod/shared/production_tenants#value"
+- name: Auth_StrivacityIdentityStore_EnvironmentMapping
+  value: "vault:secrets/data/prod/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value"
 {{- end }}
 {{- if .Values.global.dependencies.mongodb }}
 - name: KeyVault_MongoConnection


### PR DESCRIPTION
## Summary

Adds the `Auth_StrivacityIdentityStore_EnvironmentMapping` secret mapping to the csharp lang vars in `charts/mycarrier-helm/templates/_lang.tpl` for **dev**, **preprod** and **prod**, following the same pattern as `production_tenants` (7aaaeaa).

| Environment | Vault path |
| --- | --- |
| dev | `vault:secrets/data/dev/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value` |
| preprod | `vault:secrets/data/preprod/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value` |
| prod | `vault:secrets/data/prod/shared/Auth_StrivacityIdentityStore_EnvironmentMapping#value` |

## Notes

- Each environment reads from its own `secrets/data/<env>/shared/` path rather than all pointing at the prod path.
- The vault secret must exist at `<env>/shared/Auth_StrivacityIdentityStore_EnvironmentMapping` (exact casing) in each environment before rollout.
- Chart version bump is handled by the automated release workflow on merge.

## Testing

- `helm lint charts/mycarrier-helm` — passes
- `helm template` rendered for `dev`, `preprod` and `prod` with `global.language=csharp`; the new env var appears with the correct per-environment vault path in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)