### PR TITLE
feat(splitproxy): add tcpSocket readinessProbe on port 3000 (DEVOPS-176)

### DIFF
--- a/charts/splitproxy/Chart.yaml
+++ b/charts/splitproxy/Chart.yaml
@@ -3,4 +3,4 @@ name: splitproxy
 description: A Helm chart for splitproxy server and admin-dashboard
 type: application
 icon: https://www.split.io/wp-content/uploads/2017/11/split-logo-light-background-transparent.png
-version: 0.3.10
+version: 0.3.11

--- a/charts/splitproxy/templates/deployment.yaml
+++ b/charts/splitproxy/templates/deployment.yaml
@@ -58,6 +58,14 @@ spec:
               - exit $(wget -O - localhost:3010/health/application 2>/dev/null | grep -E "\"healthy\":\s*false,{0,1}" -o | wc -w;)
             initialDelaySeconds: 5
             timeoutSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 30
           env:
           {{- if .Values.environment }}
           {{- range $key, $value := .Values.environment }}


### PR DESCRIPTION
## What
Adds a `readinessProbe` (`tcpSocket` port 3000) to the splitproxy chart deployment template and bumps the chart 0.3.10 → 0.3.11.

## Why
kyverno `require-readiness-probes` (Audit) flags splitproxy on the Development app cluster because the chart ships only liveness + startup probes. This is a blocker for the DEVOPS-176 Audit→Enforce flip. Port 3000 is the app-serving proxy port (3010 is the admin/health port the exec probes already use). `tcpSocket` is a shallow process-up check — no health-endpoint or dependency coupling, matching the readiness strategy adopted org-wide in DEVOPS-176.

## Blast radius
- Chart only. On merge, `chart-releaser` publishes `splitproxy-0.3.11.tgz` to charts.mycarrier.dev.
- **No runtime effect until** the DEV-cluster ApplicationSet is repinned 0.3.10→0.3.11 (separate ManagementInfra PR, merged after this publishes). Repin covers dev+qa+uat only; **prod splitproxy stays pinned at 0.3.10** and is untouched.
- Note: helm-charts CI (`chart-version-bumper`) detects the manual Chart.yaml bump and accepts 0.3.11 as-is (no double-bump).

## Verification
- `helm lint charts/splitproxy` — pass
- `helm template` renders the readinessProbe with tcpSocket port 3000