### PR TITLE
fix(splitproxy): assert runAsNonRoot:true for kyverno enforce (DEVOPS-176)

### DIFF
--- a/charts/splitproxy/Chart.yaml
+++ b/charts/splitproxy/Chart.yaml
@@ -3,4 +3,4 @@ name: splitproxy
 description: A Helm chart for splitproxy server and admin-dashboard
 type: application
 icon: https://www.split.io/wp-content/uploads/2017/11/split-logo-light-background-transparent.png
-version: 0.3.11
+version: 0.3.12

--- a/charts/splitproxy/values.yaml
+++ b/charts/splitproxy/values.yaml
@@ -26,7 +26,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
 
 securityContext: {}
 


### PR DESCRIPTION
Part of DEVOPS-176. Adds pod-level `podSecurityContext.runAsNonRoot: true` to the splitproxy chart values (`charts/splitproxy/values.yaml`) + bumps `charts/splitproxy/Chart.yaml` 0.3.11→0.3.12. splitproxy already runs uid 1000 (no root override in any env); additive. Template already wires `.Values.podSecurityContext` to pod securityContext.

`helm lint` + `helm template` PASS (renders runAsNonRoot:true, chart label splitproxy-0.3.12).

**On merge, chart-releaser publishes 0.3.12 to charts.mycarrier.dev.** Paired with the ManagementInfra repin PR which MUST merge only AFTER this publishes.