### PR TITLE
feat(mc-environment): forward cronjobs to mycarrier-helm (0.2.10)

### DIFF
--- a/charts/mc-environment/Chart.yaml
+++ b/charts/mc-environment/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mc-environment
 description: Aggregate multiple mycarrier-helm environments into Argo CD Applications.
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: "1.0.0"

--- a/charts/mc-environment/templates/appset.yaml
+++ b/charts/mc-environment/templates/appset.yaml
@@ -36,6 +36,9 @@ spec:
                 {{ with $env.jobs }}jobs:
                   {{- toYaml . | nindent 18 }}
                   {{- end }}
+                {{ with $env.cronjobs }}cronjobs:
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
                 {{ with $env.secrets }}secrets:
                   {{- toYaml . | nindent 18 }}
                   {{- end }}

--- a/charts/mc-environment/tests/appset_test.yaml
+++ b/charts/mc-environment/tests/appset_test.yaml
@@ -228,3 +228,29 @@ tests:
       - equal:
           path: spec.generators[0].list.elements[0].Values.manualOtelConfig
           value: false
+
+  # mycarrier-helm gained cronjobs; the wrapper builds the subchart values from an explicit
+  # allowlist, so without a passthrough here the key is unreachable for every environment deploy.
+  - it: forwards cronjobs to the subchart values when an environment defines them
+    values:
+      - fixtures/basic-environments.yaml
+    documentSelector:
+      path: metadata.name
+      value: carriers-dev
+    asserts:
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.cronjobs[0].name
+          value: shipments-db-cleanup
+      - equal:
+          path: spec.generators[0].list.elements[0].Values.cronjobs[0].schedule
+          value: "0 3 * * *"
+
+  - it: omits cronjobs from the subchart values when an environment doesn't define them
+    values:
+      - fixtures/basic-environments.yaml
+    documentSelector:
+      path: metadata.name
+      value: carriers-prod
+    asserts:
+      - notExists:
+          path: spec.generators[0].list.elements[0].Values.cronjobs

--- a/charts/mc-environment/tests/fixtures/basic-environments.yaml
+++ b/charts/mc-environment/tests/fixtures/basic-environments.yaml
@@ -47,6 +47,17 @@ environments:
           - npm
           - run
           - migrate
+    cronjobs:
+      - name: shipments-db-cleanup
+        schedule: "0 3 * * *"
+        image:
+          registry: ghcr.io
+          repository: mycarrier/migrations
+          tag: "1.12.3"
+        command:
+          - npm
+          - run
+          - cleanup
     secrets:
       individual:
         - envVarName: SHIPMENTS_DB_PASSWORD

--- a/charts/mc-environment/values.schema.json
+++ b/charts/mc-environment/values.schema.json
@@ -334,6 +334,9 @@
     "jobs": {
       "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/jobs"
     },
+    "cronjobs": {
+      "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/cronjobs"
+    },
     "secrets": {
       "$ref": "https://raw.githubusercontent.com/MyCarrier-DevOps/helm-charts/refs/heads/main/charts/mycarrier-helm/values.schema.json#/properties/secrets"
     },
@@ -511,6 +514,12 @@
           "jobs": {
             "oneOf": [
               { "$ref": "#/definitions/jobs" },
+              { "type": "null" }
+            ]
+          },
+          "cronjobs": {
+            "oneOf": [
+              { "$ref": "#/definitions/cronjobs" },
               { "type": "null" }
             ]
           },


### PR DESCRIPTION
## What
- ApplicationSet generator (`appset.yaml`) now forwards `$env.cronjobs` to `mycarrier-helm`, mirroring the existing `jobs` block.
- `values.schema.json` adds an optional `cronjobs` property in 2 places: the shared `properties.cronjobs` `$ref` and the per-environment `oneOf` (`$ref: #/definitions/cronjobs` | `null`), both pointing at `mycarrier-helm`'s `values.schema.json#/properties/cronjobs`.
- Chart version bumped 0.2.9 -> 0.2.10.

## Why
`mc-environment` did not forward `cronjobs` to `mycarrier-helm`, blocking v2 CronJob rendering (needed for frontend looptesting). This fix is reusable across all `mc-environment` repos.

## Validation
- `helm lint` passes.
- Real `helm template` run on the patched chart accepts and forwards `cronjobs` (schema validates OK).
- `mycarrier-helm` renders `kind: CronJob` from the forwarded shape.
- Robustness review clean: `$ref` resolves, change is backward-compatible / no-op for repos without `cronjobs` defined, schema property is optional.

## MERGE ORDER (IMPORTANT)
This is step 1 of a hard-ordered set:
1. **Merge + publish 0.2.10 FIRST** (this PR).
2. Then the two consumer-pin PRs (workflow-dev + workflow-core, bump 0.2.9 -> 0.2.10).
3. Then the `MC.MyCarrier.Frontend` values PR.

Shipping the frontend `cronjobs` values while consumers still pin 0.2.9 hard-fails Helm schema validation.

Refs DEVOPS-176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)