### PR TITLE
fix(splitproxy): add numeric runAsUser 1000 to satisfy runAsNonRoot

### DIFF
--- a/charts/splitproxy/Chart.yaml
+++ b/charts/splitproxy/Chart.yaml
@@ -3,4 +3,4 @@ name: splitproxy
 description: A Helm chart for splitproxy server and admin-dashboard
 type: application
 icon: https://www.split.io/wp-content/uploads/2017/11/split-logo-light-background-transparent.png
-version: 0.3.12
+version: 0.3.13

--- a/charts/splitproxy/values.yaml
+++ b/charts/splitproxy/values.yaml
@@ -28,6 +28,8 @@ serviceAccount:
 
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 securityContext: {}
 


### PR DESCRIPTION
## Problem
splitproxy chart 0.3.12 set `podSecurityContext.runAsNonRoot: true`, but the `splitsoftware/split-proxy` image `USER` is the non-numeric name `split-proxy`. Kubelet cannot verify non-root for a non-numeric user without a numeric `runAsUser`, so every pod fails with `CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (split-proxy)`.
## Fix
Add numeric `runAsUser: 1000` + `runAsGroup: 1000` to `podSecurityContext`. Empirically verified: image `/etc/passwd` = `split-proxy:x:1000:1000`. Bump chart 0.3.12 -> 0.3.13.
## Validation
`helm lint` pass; `helm template` renders pod securityContext with runAsNonRoot/runAsUser:1000/runAsGroup:1000. Adversarial review confirmed pod-level runAsUser satisfies the kubelet check (empty container-SC inherits it) and the enforced kyverno require-non-root-groups policy.
## Merge order
Merge this FIRST. chart-releaser must publish `splitproxy-0.3.13` to charts.mycarrier.dev before the ManagementInfra repin PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)