### PR TITLE
feat: wire HardenedSecurityContext flag into test-engine trigger payload (DEVOPS-176)

### DIFF
--- a/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
+++ b/charts/mycarrier-helm/templates/_spec_triggertestengine.tpl
@@ -89,10 +89,14 @@ template:
           {{- if hasKey . "spreadAcrossNodes" }}
             {{- $spreadAcrossNodes = printf "%v" .spreadAcrossNodes }}
           {{- end }}
+          {{- $hardenedSecurityContext := false }}
+          {{- if hasKey . "hardenedSecurityContext" }}
+            {{- $hardenedSecurityContext = .hardenedSecurityContext }}
+          {{- end }}
           {{- $defaultPodResources := dict "limits" (dict "cpu" "2000m" "memory" "4Gi") "requests" (dict "cpu" "250m" "memory" "0.5Gi") }}
           {{- $podResources := .podResources | default $defaultPodResources }}
           {{- $testEnv := dict "EnvironmentName" $namespace "ReleaseId" $imageTag "SecretId" (.secretId | default "") "ServiceAddress" $serviceAddress "ReleaseDefinitionName" (.releaseDefinitionName | default $baseName) "BranchName" $gitBranch "AdditionalEnvVars" (.additionalEnvVars | default "") "CorrelationId" $correlationId "LegacyMode" $legacyMode }}
-          {{- $test := dict "IsMonolith" false "TestName" .name "StackName" $stackname "ContainerImage" (.containerImage | default "") "ContainerTag" (.containerTag | default "") "TestFilters" .filters "Tolerations" $tolerations "NodeAffinity" $nodeAffinity "UseDefaultNodeAffinity" $useDefaultNodeAffinity "SpreadAcrossNodes" $spreadAcrossNodes "PodResources" $podResources "TestEnvironmentVariables" $testEnv }}
+          {{- $test := dict "IsMonolith" false "TestName" .name "StackName" $stackname "ContainerImage" (.containerImage | default "") "ContainerTag" (.containerTag | default "") "HardenedSecurityContext" $hardenedSecurityContext "TestFilters" .filters "Tolerations" $tolerations "NodeAffinity" $nodeAffinity "UseDefaultNodeAffinity" $useDefaultNodeAffinity "SpreadAcrossNodes" $spreadAcrossNodes "PodResources" $podResources "TestEnvironmentVariables" $testEnv }}
           {{- $tests = append $tests $test }}
           {{- end }}
             curl -X POST \
@@ -120,6 +124,10 @@ template:
           {{- if hasKey . "spreadAcrossNodes" }}
             {{- $spreadAcrossNodes = printf "%v" .spreadAcrossNodes }}
           {{- end }}
+          {{- $hardenedSecurityContext := false }}
+          {{- if hasKey . "hardenedSecurityContext" }}
+            {{- $hardenedSecurityContext = .hardenedSecurityContext }}
+          {{- end }}
           {{- $defaultPodResources := dict "limits" (dict "cpu" "2000m" "memory" "4Gi") "requests" (dict "cpu" "250m" "memory" "0.5Gi") }}
           {{- $podResources := .podResources | default $defaultPodResources }}
             curl -X POST \
@@ -131,6 +139,7 @@ template:
               "StackName": "{{ $stackname }}",
               "ContainerImage": "{{ .containerImage }}",
               "ContainerTag": "{{ .containerTag }}",
+              "HardenedSecurityContext": {{ $hardenedSecurityContext }},
               "TestFilters": {{ .filters | toJson }},
               "Tolerations": {{ $tolerations | toJson }},
               "NodeAffinity": {{ $nodeAffinity | toJson }},

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -550,6 +550,7 @@ applications: {}
 #         secretId: "vault:Secrets/data/app_authentication#SecretId"
 #         additionalEnvVars: "key1=value1;key2=value2"
 #         legacyMode: false                      # Optional (default: false)
+#         hardenedSecurityContext: false          # Optional (default: false)
 #         useDefaultNodeAffinity: false          # Optional (default: false)
 #         spreadAcrossNodes: true                # Optional (default: true)
 #         # Optional: Pod resources for test pods (defaults shown below)


### PR DESCRIPTION
## Summary
DEVOPS-176 Step 3 (hardened-security-context chain). Adds a per-testdefinition helm value `hardenedSecurityContext` (default `false`) and forwards it into the JSON payload the `_spec_triggertestengine.tpl` template curls to the MC.TestEngine API, as the wire key `HardenedSecurityContext` (JSON boolean) on `TestConfig`.

When the API/worker (MC.TestEngine #67) sees `HardenedSecurityContext: true`, its worker applies the non-root / read-only-rootfs securityContext + scratch emptyDir volumes to the test-job pod. That pod-level logic lives entirely in #67 — this PR only forwards the opt-in flag; it does NOT emit any k8s securityContext itself.

## Changes
- `templates/_spec_triggertestengine.tpl`: read `hardenedSecurityContext` per test definition (mirrors the existing `legacyMode` idiom, `hasKey` fallback → default `false`); emit `"HardenedSecurityContext"` as an unquoted JSON boolean in BOTH the V1 (`{"Tests":[...]}`) and legacy (flat) payload branches, positioned after `ContainerTag` to match the `TestConfig` struct field order.
- `values.yaml`: documented the new optional key in the commented `testdefinitions` example (default `false`).

## Safety / blast radius
- **Default OFF → inert for every existing service.** No service sets the key, so all rendered payloads gain `"HardenedSecurityContext": false` with zero behavioral change (false == the API default).
- No opt-in in this PR. Opting a canary service in is a separate PR (Step 4), gated on MC.TestEngine #67 being merged + released first.

## Validation (no cluster)
- `helm template` rendered 4 ways — {V1, legacy} × {key absent, key=true}: key absent → `HardenedSecurityContext: false`; key=true → `true`. All payloads valid JSON.
- `helm lint` PASS. helm-unittest: 587 tests pass, no regressions.

## Not included
- k8s securityContext / emptyDir / cache-relocation logic (owned by MC.TestEngine #67).
- Canary opt-in (Step 4, separate gated PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Merge order (DEVOPS-176 hardened-security-context chain)
1. **MC.TestEngine [#67](https://github.com/MyCarrier-DevOps/MC.TestEngine/pull/67)** (worker honors `HardenedSecurityContext`) — merge **and release a worker image** FIRST.
2. **This PR (#108)** — forwards the flag, default **OFF / inert**. Safe to merge in any order (default-off is a no-op for every existing service), but the chain is not usable until #67 is released.
3. **Step 4 canary opt-in** (`hardenedSecurityContext: true` for one service) — only AFTER #67 is merged + released and steps 1&2 are done.

⛔ Do not opt any service in until #67 is merged **and** released, or that service's test jobs will send `HardenedSecurityContext: true` to a worker that cannot honor it.
