### PR TITLE
fix(vault): render vault-agent sidecar non-root (DEVOPS-176)

### DIFF
--- a/charts/mycarrier-helm/Chart.yaml
+++ b/charts/mycarrier-helm/Chart.yaml
@@ -3,5 +3,5 @@ name: mycarrier-helm
 description: A Helm chart for MyCarrier GitOps
 type: application
 icon: https://go.mycarrier.io/hs-fs/hubfs/Logos/PNG-MC-COLOR-Logo.png?width=366&height=85&name=PNG-MC-COLOR-Logo.png
-version: 3.5.4
+version: 3.5.5
 appVersion: 3.0.29

--- a/charts/mycarrier-helm/templates/_vault.tpl
+++ b/charts/mycarrier-helm/templates/_vault.tpl
@@ -4,6 +4,11 @@ vault.security.banzaicloud.io/mutate-probes: "true"
 vault.security.banzaicloud.io/vault-auth-method: azure
 vault.security.banzaicloud.io/vault-path: clusterauth
 vault.security.banzaicloud.io/vault-role: appcluster
+vault.security.banzaicloud.io/run-as-non-root: "true"
+vault.security.banzaicloud.io/run-as-user: "100"
+vault.security.banzaicloud.io/run-as-group: "1000"
+vault.security.banzaicloud.io/vault-agent-env-variables: >-
+  [{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]
 {{- if and .Values (hasKey .Values "secrets") }}
 vault.security.banzaicloud.io/vault-env-daemon: "true"
 {{- if hasKey .Values.secrets "bulk" }}


### PR DESCRIPTION
**What:** Adds 4 banzaicloud annotations to the `helm.annotations.vault` helper (`_vault.tpl`) so every vault-injected app renders its injected vault-agent sidecar as non-root: `run-as-non-root:"true"`, `run-as-user:"100"`, `run-as-group:"1000"`, and `vault-agent-env-variables:[{SKIP_CHOWN},{SKIP_SETCAP}]`. Chart bumped 3.5.4→3.5.5.

**Why:** The injected `hashicorp/vault` sidecar runs as root by default (image has no USER directive), failing the `require-run-as-non-root` kyverno policy on container[0] even though app containers are already non-root. Part of DEVOPS-176 non-root remediation.

**How it works:** `run-as-user:100` pins the sidecar to the image's built-in non-root `vault` user (uid 100/gid 1000). `SKIP_CHOWN`/`SKIP_SETCAP` stop that non-root uid crashing on the entrypoint's root-only chown/setcap steps (`chown /vault/config: Operation not permitted` / `CAP_SETFCAP`).

**Validation:** Canary-proven live in dev on `dev-accessorial/accessorial-api` — vault-agent came up `uid=100(vault)`, secrets still injected, app healthy, and `require-run-as-non-root` no longer violates the pod (verified against prior root generations that did). `helm template` confirms all 4 annotations render + the JSON value parses; `helm lint` clean.

**Rollout note (do not merge-and-forget):** This is the SOURCE fix only. It propagates to the ~117 rendered GitOps-dev manifests (67 dev + 50 preprod) via re-render, which also requires bumping the pinned `chart_version` in the render workflow. Roll out STAGED (dev subset first, then fleet) — do not big-bang across preprod. `require-ro-rootfs` is a separate follow-on track, still expected to fail.