### PR TITLE
feat(mycarrier-helm): opt-in cronjob securityContext hook (RO-rootfs, fsGroup, seccompProfile)

### DIFF
--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -1,20 +1,46 @@
+{{/*
+Resolve the workload-item securityContext dict (opt-in hardening block) regardless of
+whether the caller context is an application (.application.securityContext), a cronjob
+item (.cronjob.securityContext), or neither (defaults to an empty dict so all lookups
+below are no-ops and rendered output is unchanged).
+*/}}
+{{- define "helm.workloadSecurityContext" -}}
+{{- $sc := dict -}}
+{{- if and .application .application.securityContext -}}
+{{- $sc = .application.securityContext -}}
+{{- end -}}
+{{- if and .cronjob .cronjob.securityContext -}}
+{{- $sc = .cronjob.securityContext -}}
+{{- end -}}
+{{- $sc | toJson -}}
+{{- end -}}
+
 {{- define "helm.podSecurityContext" -}}
 {{- if and (not .Values.enableVaultCA) (not .Values.disableSecurity) }}
+{{- $sc := include "helm.workloadSecurityContext" . | fromJson }}
 securityContext:
   runAsUser: 1000
   runAsGroup: 3000
   runAsNonRoot: true
+{{- with $sc.fsGroup }}
+  fsGroup: {{ int64 . }}
+{{- end }}
+{{- with $sc.seccompProfile }}
+  seccompProfile:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end -}}
 
 {{- define "helm.containerSecurityContext" -}}
 {{- if and (not .Values.enableVaultCA) (not .Values.disableSecurity) }}
+{{- $sc := include "helm.workloadSecurityContext" . | fromJson }}
 securityContext:
   runAsUser: 1000
   runAsGroup: 3000
   privileged: false
   runAsNonRoot: true
-  readOnlyRootFilesystem: {{ if and .application .application.securityContext .application.securityContext.readOnlyRootFilesystem }}true{{ else }}false{{ end }}
+  readOnlyRootFilesystem: {{ if $sc.readOnlyRootFilesystem }}true{{ else }}false{{ end }}
   allowPrivilegeEscalation: false
   capabilities:
     drop:

--- a/charts/mycarrier-helm/templates/_spec_cronjob.tpl
+++ b/charts/mycarrier-helm/templates/_spec_cronjob.tpl
@@ -48,6 +48,9 @@ jobTemplate:
         annotations:
           {{ include "helm.annotations.vault" . | indent 10 | trim }}
           {{ include "helm.otel.annotations" . | indent 10 | trim }}
+          {{- with .cronjob.annotations }}
+          {{ toYaml . | indent 10 | trim }}
+          {{- end }}
       spec:
         {{ include "helm.podSecurityContext" . | indent 8 | trim }}
         serviceAccountName: default

--- a/charts/mycarrier-helm/tests/cronjob_test.yaml
+++ b/charts/mycarrier-helm/tests/cronjob_test.yaml
@@ -176,6 +176,28 @@ tests:
           path: metadata.annotations["argocd.argoproj.io/sync-options"]
           value: "Prune=true"
 
+  - it: should render custom annotations onto the pod template too (e.g. istio sidecar opt-out)
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          annotations:
+            sidecar.istio.io/inject: "false"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+
   - it: should set job deadline and backoff limit
     set:
       environment.name: "dev"

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -603,6 +603,14 @@
               "readOnlyRootFilesystem": {
                 "type": "boolean",
                 "default": false
+              },
+              "fsGroup": {
+                "type": "integer",
+                "description": "Pod-level fsGroup (opt-in; unset by default)"
+              },
+              "seccompProfile": {
+                "type": "object",
+                "description": "Pod-level seccompProfile (opt-in; unset by default)"
               }
             }
           },
@@ -1966,6 +1974,25 @@
                   "type": "object",
                   "description": "Custom volume definition"
                 }
+              }
+            }
+          },
+          "securityContext": {
+            "type": "object",
+            "description": "Opt-in hardened security context for this cronjob",
+            "properties": {
+              "readOnlyRootFilesystem": {
+                "type": "boolean",
+                "description": "Container-level readOnlyRootFilesystem (opt-in; unset defaults to false)",
+                "default": false
+              },
+              "fsGroup": {
+                "type": "integer",
+                "description": "Pod-level fsGroup (opt-in; unset by default)"
+              },
+              "seccompProfile": {
+                "type": "object",
+                "description": "Pod-level seccompProfile (opt-in; unset by default)"
               }
             }
           }

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -109,7 +109,7 @@ deployment: deployment
 ## **Container**: image.registry, image.repository, image.tag, pullPolicy, pullSecret
 ## **Resources**: resources.requests.cpu/memory, resources.limits.cpu/memory
 ## **Health Probes**: probes.enableLiveness, probes.enableReadiness, probes.enableStartup (all default true; set to false to disable), custom probe configurations
-## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back)
+## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back), securityContext.fsGroup (opt-in pod-level fsGroup; previously ignored/silently dropped, now honored), securityContext.seccompProfile (opt-in pod-level seccompProfile; previously ignored/silently dropped, now honored)
 ## **Service**: service.type, service.ports, service.annotations, service.timeout, service.retryOn
 ## **Networking**: networking.ingress.type, networking.istio.enabled/hosts/routes/corsPolicy/allowedEndpoints
 ## **Autoscaling**: HPA (autoscaling.minReplicas/maxReplicas/targetCPU/targetMemory), VPA (vpa.enabled/updateMode/resources)
@@ -638,7 +638,18 @@ jobs: []
 ## Each cronjob supports: name, schedule (required), timeZone, concurrencyPolicy, suspend,
 ## successfulJobsHistoryLimit, failedJobsHistoryLimit, startingDeadlineSeconds, activeDeadlineSeconds,
 ## backoffLimit, restartPolicy, labels, annotations, image (registry/repository/tag), imagePullPolicy,
-## imagePullSecret, command, args, env, configMapName, secretName, resources (requests/limits), volumes
+## imagePullSecret, command, args, env, configMapName, secretName, resources (requests/limits), volumes,
+## securityContext (opt-in hardened security context, see below)
+##
+## **Security Context (opt-in)**: securityContext.readOnlyRootFilesystem (default false; sets the
+## container's readOnlyRootFilesystem), securityContext.fsGroup (unset by default; sets the pod-level
+## fsGroup), securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
+## {type: RuntimeDefault}). All three are opt-in per cronjob item — omitting securityContext entirely
+## preserves the chart's existing default rendering.
+##
+## IMPORTANT: the cluster's kyverno `restrict-seccomp` policy is Enforce and only allows
+## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
+## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
 ##
 ## See the example configuration below for complete cronjob specification details.
 
@@ -691,7 +702,14 @@ cronjobs: []
 #     limits:
 #       cpu: "500m"
 #       memory: "512Mi"
-#   
+#
+#   # Optional: Hardened security context (opt-in; omit entirely to keep default rendering)
+#   # securityContext:
+#   #   readOnlyRootFilesystem: true
+#   #   fsGroup: 3000
+#   #   seccompProfile:
+#   #     type: RuntimeDefault
+#
 #   # Optional: Volume mounts
 #   # volumes:
 #   #   - name: backup-storage

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -651,6 +651,11 @@ jobs: []
 ## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
 ## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
 ##
+## `annotations` now also render onto the CronJob pod template (in addition to the CronJob resource
+## itself), so it can be used to set per-cronjob pod annotations — e.g. `sidecar.istio.io/inject: "false"`
+## to opt a CronJob's pods out of Istio sidecar injection in istio-injection=enabled namespaces (a
+## never-exiting sidecar container otherwise hangs the Job).
+##
 ## See the example configuration below for complete cronjob specification details.
 
 ## @param cronjobs [array] List of Kubernetes CronJobs to run


### PR DESCRIPTION
## Why

bd mycarrier-e8td — this is the chart wiring that unblocks the dev-looptest cronjob read-only-rootfs flip (DEVOPS-176). MC.MyCarrier.Frontend PR #123 already made the workload RO-ready (cache moved to `/tmp`, TestResults now an emptyDir), and the container already runs as non-root (image `USER 1000:3000`). The only piece missing was a chart-level hook to actually turn on `readOnlyRootFilesystem` (and the related pod-level `fsGroup`/`seccompProfile`) for a cronjob. This PR adds that hook. It also advances kyverno "heavies" readiness (bd mycarrier-c463.9) for the looptest namespace.

## What

- New opt-in keys: `cronjobs[].securityContext.readOnlyRootFilesystem`, `cronjobs[].securityContext.fsGroup`, `cronjobs[].securityContext.seccompProfile`. If you don't set `securityContext` on a cronjob item, nothing changes — the rendered manifest is identical to before.
- A shared `helm.workloadSecurityContext` helper in `_podsecurity.tpl` that resolves the security context dict from either an application (`.application.securityContext`, already existed) or a cronjob item (`.cronjob.securityContext`, new). This keeps the deployment/statefulset/rollout/job/triggertestengine paths untouched while adding cronjob support.
- `fsGroup` is now cast through `int64` when rendered. Without this, large cluster-assigned group IDs (anything ≥ ~1,000,000, which is realistic for cluster-assigned GIDs) rendered in scientific notation (e.g. `1.00066e+09`) that the Kubernetes API server rejects outright. Fixed and verified with a real large value.
- `values.schema.json` now types the new `cronjobs[].securityContext` block (`readOnlyRootFilesystem`: boolean, `fsGroup`: integer, `seccompProfile`: object), and also adds `fsGroup`/`seccompProfile` typing to the existing `applications[].securityContext` block.
- `values.yaml` docs explain the new keys, including a callout that the cluster's kyverno `restrict-seccomp` policy is in Enforce mode and only allows `seccompProfile.type: RuntimeDefault` (or `runtime/default`) — `Localhost` will render fine from the chart but gets hard-rejected at admission, so don't use it.

## Also: cronjobs[].annotations now reaches the pod template

`cronjobs[].annotations` was already documented in the schema ("Custom annotations to add to the cronjob resources") and was already rendering onto the `CronJob` object's own `metadata.annotations` — but it never reached the `jobTemplate.spec.template.metadata.annotations` (the pod template). That matters because Istio's sidecar injector reads annotations off the **pod**, not the CronJob resource. In namespaces with `istio-injection=enabled` (e.g. `uat`), a CronJob's pods would silently pick up an Istio sidecar that never exits on its own, which hangs the Job (it waits for all containers to exit). Same `cronjobs[].annotations` key now also renders onto the pod template, so setting `annotations: {sidecar.istio.io/inject: "false"}` on a cronjob opts its pods out of injection. Mirrors the existing `_spec_deployment.tpl` annotations-passthrough idiom; added a helm-unittest case asserting the annotation lands on both the CronJob resource and the pod template.

## Evidence

- `helm lint` passes with default values and with the new opt-in values set (security context and annotations).
- Default (no new keys) renders are byte-identical before/after this change, verified via diff across all six workload templates that share the security-context helpers: deployment, job, rollout, statefulset, triggertestengine, and cronjob.
- `helm unittest` — 588/588 tests passing across all 59 existing test suites (587 baseline + 1 new test for the pod-template annotations passthrough), no regressions.
- This change went through an adversarial review pass. Two must-fix findings came back and were fixed and re-verified:
  1. The `fsGroup` scientific-notation rendering issue described above (now fixed with `int64`, confirmed with `fsGroup: 1000660000` rendering as a literal integer).
  2. The schema previously had no type enforcement on these new keys. It's now typed, so e.g. setting `fsGroup: "abc"` (a string instead of a number) correctly fails `helm lint`/`helm template` with `got string, want integer`.

## Known limitations (intentional, not gaps)

- `jobs[]` (one-off Kubernetes Jobs, distinct from `cronjobs[]`) is **not** covered by this hook — that's a separate track handled by the MC.TestEngine worker.
- Typo'd keys (e.g. `fsgroup` instead of `fsGroup`) are still a silent no-op — there's no `additionalProperties: false` at this level of the schema, which matches how the rest of this chart's schema is already written. Worth a follow-up if we want stricter validation chart-wide, but out of scope here.
- `Chart.yaml` version was intentionally left untouched — this repo's CI (`chart-version-bumper`) auto-bumps the chart version on merge to `main`.

## Validation results (2026-08-07, offline estate-wide)

**Estate-wide render diff — no-op confirmed.** Every real consumer of `mycarrier-helm` in GitOps-dev and GitOps-prod was render-diffed against this branch vs `origin/main` (3.5.6), using the actual inline `Values` blobs from the committed ApplicationSet manifests as inputs: 82 ApplicationSet documents (80 dev, 2 prod) plus 45 offload-branch merged variants — **127 render inputs, 127 zero-byte diffs, 0 render failures on either side**. Since every existing values blob renders cleanly against this branch, the new `values.schema.json` entries reject no existing consumer.

**Latent behavior change has zero consumers.** `applications[].securityContext.fsGroup` / `.seccompProfile` are now emitted into pod specs where they were previously ignored. A grep over all extracted consumer values and the raw GitOps trees found **zero** workloads setting those keys — no pod spec changes anywhere on version bump.

**Template coverage.** The diff exercised deployment (475 rendered), job (120), and the other actively-used templates. rollout, statefulset, and cronjob have zero real-world instances in the estate; the cronjob path (this PR's target) is instead proven by the dev-looptest live test below. 

**Quality gates.** `helm lint` clean; `helm unittest` **588/588 across 59 suites**.

**Cronjob opt-in path proven live.** The MC.MyCarrier.Frontend dev-looptest CronJobs (first consumer of the new keys) were live-tested in three rounds on the Development cluster against this branch: zero EROFS across ~26k log lines, 33/33 tests per run, kyverno 21/21 pass per pod including require-ro-rootfs and require-run-as-non-root. Re-rendering that entry against this branch reproduces the tested manifests **identically except the deliberate `suspend: true`** line (structural YAML comparison; securityContext, annotations, containers, volumes all exact).

Full reports: `standup-notes/2026/08/pr110-estate-render-diff.md`, `standup-notes/2026/08/pr110-looptest-rerender.md` (mycarrier workspace repo).

## Rollout plan

1. **Merge this PR** — chart-version-bumper CI cuts `mycarrier-helm` 3.5.7 (Chart.yaml intentionally not hand-bumped).
2. **Bump `mycarrier_helm: "3.5.7"` in workflow-dev only** (`workflows/templates/render-deploy-core.yaml`). workflow-dev serves only the dev render path (argo-events-test / test-webhook), so this scopes 3.5.7 to dev renders. Nothing auto-redeploys on the bump itself; repos pick it up on their next deploy (plus `mc-env-tag-reset` cron renders on its schedule).
3. **Canary**: dispatch one low-risk Deployment-based dev service; diff its regenerated appset in GitOps-dev, capture live pod securityContext before/after, watch for CreateContainerConfigError/restart loops, confirm kyverno policy reports unchanged.
4. **Promote the pin to workflow-core** — preprod/prod renders move to 3.5.7 on their next deploys.
5. **Bulk-update all GitOps-dev apps to 3.5.7** — scripted `targetRevision` bump across all ~80 mycarrier-helm ApplicationSets in one PR; expected churn is chart version only (render diff above proves manifests byte-identical). Watch Argo app health and kyverno report deltas after sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
