### PR TITLE
fix(mycarrier-helm): dedupe cronjob annotation keys + cover the securityContext hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ charts/trino/charts-main/charts/trino/templates/serviceaccount.yaml
 */.DS_Store
 .DS_Store
 __snapshot__
+!charts/mycarrier-helm/tests/__snapshot__/
 .vscode
 .debug

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1054,6 +1054,9 @@ cronjobs:
 | `configMapName` | ConfigMap to load as environment variables | None |
 | `secretName` | Secret to load as environment variables | None |
 | `resources` | CPU and memory resource limits | Defaults set |
+| `labels` | Custom labels added to the CronJob resource | `{}` |
+| `annotations` | Custom annotations, rendered onto BOTH the CronJob resource metadata and the CronJob pod template (filtered against chart-managed keys — see [Security Context and Reserved Annotations](#security-context-and-reserved-annotations)) | `{}` |
+| `securityContext` | Opt-in hardened security context (`readOnlyRootFilesystem`, `fsGroup`, `seccompProfile`) — see [Security Context and Reserved Annotations](#security-context-and-reserved-annotations) | unset |
 | `volumes` | Volume mounts configuration | `[]` |
 
 #### Cron Schedule Examples
@@ -1242,6 +1245,85 @@ disableOtelAutoinstrumentation: false  # opt in; default true leaves it off
 Adds the operator's injection annotations for `nodejs`/`java`/`python` and the nodejs
 `NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register` hook. Note the operator
 may also set `NODE_OPTIONS` itself when it injects.
+
+## Security Context and Reserved Annotations
+
+### securityContext (applications / jobs / cronjobs)
+
+All three workload surfaces (`applications[].securityContext`, `jobs[].securityContext`,
+`cronjobs[].securityContext`) support the same opt-in keys. Omitting `securityContext` entirely
+preserves the chart's existing default rendering — nothing changes until you set one of these:
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `readOnlyRootFilesystem` | `false` | Sets the container's `readOnlyRootFilesystem`. |
+| `addCapabilities` | `[]` | Applications only. All capabilities are dropped by default (`drop: [ALL]`); list specific capabilities here to add them back. |
+| `fsGroup` | unset | Sets the pod-level `fsGroup`. Must be `>= 1` — `0` is the root group and is rejected by the values schema. **This lower bound is ORG POLICY**, enforced by `MyCarrier-DevOps/kyverno-policies` `require-non-root-groups` (rule `check-fsGroup`: "must be empty or greater than zero") — it is **not** an upstream Pod Security Standards control. The [PSS spec](https://kubernetes.io/docs/concepts/security/pod-security-standards/) contains zero occurrences of `fsGroup`/`runAsGroup`/`supplementalGroups`; those were PodSecurityPolicy fields, and PSP is retired. |
+| `seccompProfile` | unset | Sets the pod-level `seccompProfile`, e.g. `{type: RuntimeDefault}`. |
+
+**seccompProfile and the `restrict-seccomp` kyverno policy**: the ClusterPolicy differs per cluster,
+because each app cluster syncs its own branch of `MyCarrier-DevOps/kyverno-policies` (verified as of
+2026-08-08):
+
+| Cluster | `validationFailureAction` | Accepted pattern | Effect on `RuntimeDefault` |
+| --- | --- | --- | --- |
+| development | `Enforce` | `runtime/default \| RuntimeDefault` | Passes, IS enforced at admission. |
+| data, production-csp | `Audit` (report-only) | `runtime/default` (literal only) | Records a PolicyReport entry; nothing is blocked. |
+
+Use `RuntimeDefault`: it is the correct value for the Kubernetes `SeccompProfile.type` field
+(`runtime/default` is the pre-1.25 annotation form and is not a legal field value), and the Pod
+Security Standards `restricted` profile permits both `RuntimeDefault` and `Localhost`, forbidding
+only `Unconfined`.
+
+### Annotation precedence and reserved keys
+
+`annotations` on any workload surface is filtered before rendering: chart-managed annotations
+**always win**. A user-supplied key that collides with a chart-managed key is **dropped** from
+`annotations` — it does not override the chart's value and does not render twice. The reserved set
+is an **exact-key match** (Helm's `hasKey`), not a `vault.security.banzaicloud.io/*` prefix match —
+any key outside the table below (including other `vault.security.banzaicloud.io/*` annotations the
+chart doesn't set) is applied to the pod/resource as-is.
+
+| Surface | Reserved keys |
+| --- | --- |
+| Application pod template (Deployment / StatefulSet / Rollout) | vault keys + otel keys (see below) + `sidecar.istio.io/inject`, `proxy.istio.io/config` + `mycarrier.io/gateway` |
+| CronJob resource metadata | `argocd.argoproj.io/sync-options` |
+| CronJob pod template | vault keys + otel keys only (no argocd/istio/gateway keys) |
+| Job resource metadata | `argocd.argoproj.io/sync-options` |
+| Job pod template | vault keys + otel keys + `argocd.argoproj.io/sync-options`, `argocd.argoproj.io/hook-delete-policy`, `argocd.argoproj.io/sync-wave`, `argocd.argoproj.io/hook` (the four argocd keys are reserved unconditionally, even though `sync-wave`/`hook` only render when `.timing` is set) |
+
+**vault keys**: `vault-addr`, `vault-auth-method`, `vault-path`, `vault-role`,
+`vault-agent-env-variables`, `mutate-probes`, `run-as-non-root`, `run-as-user`, `run-as-group`, plus
+`vault-env-daemon` (only when `secrets` is set) and `vault-env-from-path` (only when
+`secrets.bulk.path` is set).
+
+**otel keys**: `sidecar.opentelemetry.io/inject`, `instrumentation.opentelemetry.io/container-names`,
+and `instrumentation.opentelemetry.io/inject-<language>` for the one resolved language only —
+rendered only when `manualOtelConfig` is not `true` AND `disableOtelAutoinstrumentation: false` AND
+the language is `nodejs`/`java`/`python`.
+
+**Unmanaged keys pass through as-is** — including security-relevant ones. Verified: `vault-skip-verify`
+(disables TLS verification to Vault), `mutate: skip` (disables secret injection entirely),
+`vault-namespace`, `vault-serviceaccount`. `psp-allow-privilege-escalation` also renders through but
+is not documented in the current bank-vaults reference.
+
+**Istio override is closed on application surfaces**: `sidecar.istio.io/inject`,
+`proxy.istio.io/config`, and `mycarrier.io/gateway` set in `applications[].annotations` are dropped —
+the chart's own computed values always win. Use `applications[].istioDisabled`,
+`applications[].networking.istio.enabled`, or `applications[].service.istioDisabled` instead.
+
+This does **not** apply to `cronjobs[]`/`jobs[]` — their pod templates emit no istio annotations of
+their own, so `sidecar.istio.io/inject: "false"` set via `cronjobs[].annotations` /
+`jobs[].annotations` still passes through and remains the documented way to stop a never-exiting
+sidecar from hanging a CronJob/Job. This matters more for Jobs than CronJobs: chart Jobs are ArgoCD
+PreSync/PostSync hooks, so a never-exiting sidecar on a Job pod blocks the entire application sync,
+not just one Job run. `jobs[].annotations` now render onto both the Job resource metadata and the
+Job pod template (filtered), mirroring `cronjobs[].annotations`.
+
+The reserved set is also context-dependent: a key that is free today can become chart-managed when a
+related feature is enabled (e.g. turning on otel autoinstrumentation), at which point the user's
+value stops taking effect. This is deliberate — the alternative (failing the template render) would
+turn an unrelated future "enable otel" change into a hard non-local build break.
 
 ## Troubleshooting
 

--- a/charts/mycarrier-helm/templates/_annotations.tpl
+++ b/charts/mycarrier-helm/templates/_annotations.tpl
@@ -5,6 +5,18 @@ as a duplicate YAML key. Returns "" when nothing survives, so callers can guard 
 */}}
 {{- define "helm.annotations.userExtra" -}}
 {{- $reserved := .reserved | default dict -}}
+{{- /* Fail fast on a CHART-AUTHORED parse failure only. `fromYaml` returns a non-empty
+     {"Error": "..."} map (not nil) when one of the chart's own annotation snippets fails
+     to parse as YAML, so a plain `hasKey $reserved "Error"` here can only be tripped by
+     chart-managed content: $reserved is built exclusively from `include ... | fromYaml`
+     calls over chart templates (helm.annotations.vault/istio/gateway, helm.otel.annotations,
+     helm.annotations.cronjobMetadata/jobMetadata, the argocd reserved-key dict) — user
+     annotations are never merged into $reserved, only compared against it below — so a
+     user annotation literally keyed "Error" cannot land in $reserved and cannot trigger
+     this guard. Do NOT generalise this into failing on user input: the chart's policy is
+     that a colliding user key is silently dropped (see the file header comment), never
+     fatal. */ -}}
+{{- if hasKey $reserved "Error" }}{{- fail (printf "helm.annotations.userExtra: chart-managed annotations failed to parse: %v" (get $reserved "Error")) }}{{- end }}
 {{- $out := dict -}}
 {{- range $k, $v := (.user | default dict) -}}
 {{- if not (hasKey $reserved $k) -}}
@@ -24,4 +36,14 @@ rather than hardcoding the key twice and risking drift.
 */}}
 {{- define "helm.annotations.cronjobMetadata" -}}
 argocd.argoproj.io/sync-options: Prune=true
+{{- end -}}
+
+{{/*
+The chart-managed Job *metadata* annotations (as opposed to the pod-template annotations
+covered by helm.annotations.vault / helm.otel.annotations). Kept as its own define so
+jobs.yaml can derive its reserved-key set from the exact same source it renders from,
+rather than hardcoding the key twice and risking drift.
+*/}}
+{{- define "helm.annotations.jobMetadata" -}}
+argocd.argoproj.io/sync-options: Force=true,Replace=true
 {{- end -}}

--- a/charts/mycarrier-helm/templates/_annotations.tpl
+++ b/charts/mycarrier-helm/templates/_annotations.tpl
@@ -1,0 +1,27 @@
+{{/*
+Emit the user-supplied annotations that do NOT collide with chart-managed keys.
+Chart-managed keys always win: a colliding user key is dropped rather than emitted
+as a duplicate YAML key. Returns "" when nothing survives, so callers can guard with `if`.
+*/}}
+{{- define "helm.annotations.userExtra" -}}
+{{- $reserved := .reserved | default dict -}}
+{{- $out := dict -}}
+{{- range $k, $v := (.user | default dict) -}}
+{{- if not (hasKey $reserved $k) -}}
+{{- $_ := set $out $k $v -}}
+{{- end -}}
+{{- end -}}
+{{- if $out -}}
+{{- toYaml $out -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The chart-managed CronJob *metadata* annotations (as opposed to the pod-template annotations
+covered by helm.annotations.vault / helm.otel.annotations). Kept as its own define so
+cronjob.yaml can derive its reserved-key set from the exact same source it renders from,
+rather than hardcoding the key twice and risking drift.
+*/}}
+{{- define "helm.annotations.cronjobMetadata" -}}
+argocd.argoproj.io/sync-options: Prune=true
+{{- end -}}

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -3,16 +3,17 @@ Resolve the workload-item securityContext dict (opt-in hardening block) regardle
 whether the caller context is an application (.application.securityContext), a cronjob
 item (.cronjob.securityContext), a job item (.job.securityContext), or neither (defaults
 to an empty dict so all lookups below are no-ops and rendered output is unchanged).
+The three sources are mutually exclusive (application -> cronjob -> job precedence,
+matching the exclusive if/else-if chain used in _labels.tpl) since a single caller
+context only ever carries one of .application/.cronjob/.job.
 */}}
 {{- define "helm.workloadSecurityContext" -}}
 {{- $sc := dict -}}
 {{- if and .application .application.securityContext -}}
 {{- $sc = .application.securityContext -}}
-{{- end -}}
-{{- if and .cronjob .cronjob.securityContext -}}
+{{- else if and .cronjob .cronjob.securityContext -}}
 {{- $sc = .cronjob.securityContext -}}
-{{- end -}}
-{{- if and .job .job.securityContext -}}
+{{- else if and .job .job.securityContext -}}
 {{- $sc = .job.securityContext -}}
 {{- end -}}
 {{- $sc | toJson -}}
@@ -25,12 +26,12 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 3000
   runAsNonRoot: true
-{{- with $sc.fsGroup }}
-  fsGroup: {{ int64 . }}
+{{- if hasKey $sc "fsGroup" }}
+  fsGroup: {{ int64 $sc.fsGroup }}
 {{- end }}
-{{- with $sc.seccompProfile }}
+{{- if hasKey $sc "seccompProfile" }}
   seccompProfile:
-{{ toYaml . | indent 4 }}
+{{ toYaml $sc.seccompProfile | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -1,8 +1,8 @@
 {{/*
 Resolve the workload-item securityContext dict (opt-in hardening block) regardless of
 whether the caller context is an application (.application.securityContext), a cronjob
-item (.cronjob.securityContext), or neither (defaults to an empty dict so all lookups
-below are no-ops and rendered output is unchanged).
+item (.cronjob.securityContext), a job item (.job.securityContext), or neither (defaults
+to an empty dict so all lookups below are no-ops and rendered output is unchanged).
 */}}
 {{- define "helm.workloadSecurityContext" -}}
 {{- $sc := dict -}}
@@ -11,6 +11,9 @@ below are no-ops and rendered output is unchanged).
 {{- end -}}
 {{- if and .cronjob .cronjob.securityContext -}}
 {{- $sc = .cronjob.securityContext -}}
+{{- end -}}
+{{- if and .job .job.securityContext -}}
+{{- $sc = .job.securityContext -}}
 {{- end -}}
 {{- $sc | toJson -}}
 {{- end -}}

--- a/charts/mycarrier-helm/templates/_spec_cronjob.tpl
+++ b/charts/mycarrier-helm/templates/_spec_cronjob.tpl
@@ -48,8 +48,10 @@ jobTemplate:
         annotations:
           {{ include "helm.annotations.vault" . | indent 10 | trim }}
           {{ include "helm.otel.annotations" . | indent 10 | trim }}
-          {{- with .cronjob.annotations }}
-          {{ toYaml . | indent 10 | trim }}
+          {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml | default dict) (include "helm.otel.annotations" $ | fromYaml | default dict) }}
+          {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" $.cronjob.annotations) }}
+          {{- if $extra }}
+          {{ $extra | indent 10 | trim }}
           {{- end }}
       spec:
         {{ include "helm.podSecurityContext" . | indent 8 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_cronjob.tpl
+++ b/charts/mycarrier-helm/templates/_spec_cronjob.tpl
@@ -48,7 +48,7 @@ jobTemplate:
         annotations:
           {{ include "helm.annotations.vault" . | indent 10 | trim }}
           {{ include "helm.otel.annotations" . | indent 10 | trim }}
-          {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml | default dict) (include "helm.otel.annotations" $ | fromYaml | default dict) }}
+          {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml) (include "helm.otel.annotations" $ | fromYaml) }}
           {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" $.cronjob.annotations) }}
           {{- if $extra }}
           {{ $extra | indent 10 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_deployment.tpl
+++ b/charts/mycarrier-helm/templates/_spec_deployment.tpl
@@ -69,8 +69,16 @@ template:
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
       {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
-      {{ with .application.annotations }}
-      {{ toYaml . |  indent 6 | trim }}
+      {{/* Istio/gateway annotations are reserved: application.istioDisabled, networking.istio.enabled,
+           and service.istioDisabled are the supported per-workload knobs for opting out of Istio sidecar
+           injection / the gateway annotation (see helm.annotations.istio / helm.annotations.gateway).
+           Allowing application.annotations to override sidecar.istio.io/inject, proxy.istio.io/config,
+           or mycarrier.io/gateway is therefore redundant and was closing over a duplicate-key defect
+           (last-key-wins on the rendered YAML, silently skipped by scanners). */}}
+      {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml) (include "helm.annotations.istio" . | fromYaml) (include "helm.annotations.gateway" . | fromYaml) (include "helm.otel.annotations" $ | fromYaml) }}
+      {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .application.annotations) }}
+      {{- if $extra }}
+      {{ $extra | indent 6 | trim }}
       {{- end }}
   spec:
     {{ include "helm.podDefaultAffinity" . | indent 4 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_job.tpl
+++ b/charts/mycarrier-helm/templates/_spec_job.tpl
@@ -32,6 +32,15 @@ template:
       {{- end }}
       {{ include "helm.annotations.vault" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" . | indent 6 | trim }}
+      {{- /* The four argocd.argoproj.io/* keys are reserved unconditionally, even though sync-wave/hook
+           only render when .job.timing is set. This keeps the reserved set independent of .job.timing,
+           so enabling a hook later cannot silently change which user keys survive. */}}
+      {{- $argocdReserved := dict "argocd.argoproj.io/sync-options" "" "argocd.argoproj.io/hook-delete-policy" "" "argocd.argoproj.io/sync-wave" "" "argocd.argoproj.io/hook" "" }}
+      {{- $reserved := merge (dict) $argocdReserved (include "helm.annotations.vault" . | fromYaml) (include "helm.otel.annotations" . | fromYaml) }}
+      {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .job.annotations) }}
+      {{- if $extra }}
+      {{ $extra | indent 6 | trim }}
+      {{- end }}
   spec:
     {{ include "helm.podSecurityContext" . | indent 4 | trim }}
     serviceAccountName: default

--- a/charts/mycarrier-helm/templates/_spec_rollout.tpl
+++ b/charts/mycarrier-helm/templates/_spec_rollout.tpl
@@ -79,8 +79,16 @@ template:
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
       {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
-      {{ with .application.annotations }}
-      {{ toYaml . | indent 6 | trim }}
+      {{/* Istio/gateway annotations are reserved: application.istioDisabled, networking.istio.enabled,
+           and service.istioDisabled are the supported per-workload knobs for opting out of Istio sidecar
+           injection / the gateway annotation (see helm.annotations.istio / helm.annotations.gateway).
+           Allowing application.annotations to override sidecar.istio.io/inject, proxy.istio.io/config,
+           or mycarrier.io/gateway is therefore redundant and was closing over a duplicate-key defect
+           (last-key-wins on the rendered YAML, silently skipped by scanners). */}}
+      {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml) (include "helm.annotations.istio" . | fromYaml) (include "helm.annotations.gateway" . | fromYaml) (include "helm.otel.annotations" $ | fromYaml) }}
+      {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .application.annotations) }}
+      {{- if $extra }}
+      {{ $extra | indent 6 | trim }}
       {{- end }}
   spec:
     {{ include "helm.podDefaultAffinity" . | indent 4 | trim }}

--- a/charts/mycarrier-helm/templates/_spec_statefulset.tpl
+++ b/charts/mycarrier-helm/templates/_spec_statefulset.tpl
@@ -31,8 +31,16 @@ template:
       {{ include "helm.annotations.istio" . | indent 6 | trim }}
       {{ include "helm.annotations.gateway" . | indent 6 | trim }}
       {{ include "helm.otel.annotations" $ | indent 6 | trim }}
-      {{- with .application.annotations }}
-      {{ toYaml . |  indent 6 | trim }}
+      {{- /* Istio/gateway annotations are reserved: application.istioDisabled, networking.istio.enabled,
+           and service.istioDisabled are the supported per-workload knobs for opting out of Istio sidecar
+           injection / the gateway annotation (see helm.annotations.istio / helm.annotations.gateway).
+           Allowing application.annotations to override sidecar.istio.io/inject, proxy.istio.io/config,
+           or mycarrier.io/gateway is therefore redundant and was closing over a duplicate-key defect
+           (last-key-wins on the rendered YAML, silently skipped by scanners). */}}
+      {{- $reserved := merge (dict) (include "helm.annotations.vault" $ | fromYaml) (include "helm.annotations.istio" . | fromYaml) (include "helm.annotations.gateway" . | fromYaml) (include "helm.otel.annotations" $ | fromYaml) }}
+      {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .application.annotations) }}
+      {{- if $extra }}
+      {{ $extra | indent 6 | trim }}
       {{- end }}
   spec:
     {{ include "helm.podDefaultAffinity" . | indent 4 | trim }}

--- a/charts/mycarrier-helm/templates/cronjob.yaml
+++ b/charts/mycarrier-helm/templates/cronjob.yaml
@@ -20,9 +20,11 @@ metadata:
     {{ toYaml .labels | indent 4 | trim }}
     {{- end }}
   annotations:
-    argocd.argoproj.io/sync-options: Prune=true
-  {{- with .annotations }}
-    {{ toYaml . | indent 4 | trim }}
+    {{ include "helm.annotations.cronjobMetadata" . | indent 4 | trim }}
+  {{- $reserved := include "helm.annotations.cronjobMetadata" . | fromYaml | default dict }}
+  {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .annotations) }}
+  {{- if $extra }}
+    {{ $extra | indent 4 | trim }}
   {{- end }}
 spec:
   {{ include "helm.specs.cronjob" $rootContext | indent 2 | trim }}

--- a/charts/mycarrier-helm/templates/cronjob.yaml
+++ b/charts/mycarrier-helm/templates/cronjob.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
   annotations:
     {{ include "helm.annotations.cronjobMetadata" . | indent 4 | trim }}
-  {{- $reserved := include "helm.annotations.cronjobMetadata" . | fromYaml | default dict }}
+  {{- $reserved := include "helm.annotations.cronjobMetadata" . | fromYaml }}
   {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .annotations) }}
   {{- if $extra }}
     {{ $extra | indent 4 | trim }}

--- a/charts/mycarrier-helm/templates/jobs.yaml
+++ b/charts/mycarrier-helm/templates/jobs.yaml
@@ -20,9 +20,11 @@ metadata:
     {{ toYaml .labels | indent 4 | trim }}
     {{- end }}
   annotations:
-    argocd.argoproj.io/sync-options: Force=true,Replace=true
-  {{- with .annotations }}
-    {{ toYaml . | indent 4 | trim }}
+    {{ include "helm.annotations.jobMetadata" . | indent 4 | trim }}
+  {{- $reserved := include "helm.annotations.jobMetadata" . | fromYaml }}
+  {{- $extra := include "helm.annotations.userExtra" (dict "reserved" $reserved "user" .annotations) }}
+  {{- if $extra }}
+    {{ $extra | indent 4 | trim }}
   {{- end }}
 spec:
   {{ include "helm.specs.job" $rootContext | indent 2 | trim }}

--- a/charts/mycarrier-helm/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/mycarrier-helm/tests/__snapshot__/cronjob_test.yaml.snap
@@ -1,0 +1,16 @@
+should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard):
+  1: |
+    vault.security.banzaicloud.io/mutate-probes: "true"
+    vault.security.banzaicloud.io/run-as-group: "1000"
+    vault.security.banzaicloud.io/run-as-non-root: "true"
+    vault.security.banzaicloud.io/run-as-user: "100"
+    vault.security.banzaicloud.io/vault-addr: https://vault.mycarrier.tech
+    vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+    vault.security.banzaicloud.io/vault-auth-method: azure
+    vault.security.banzaicloud.io/vault-env-daemon: "true"
+    vault.security.banzaicloud.io/vault-path: clusterauth
+    vault.security.banzaicloud.io/vault-role: appcluster
+  2: |
+    runAsGroup: 3000
+    runAsNonRoot: true
+    runAsUser: 1000

--- a/charts/mycarrier-helm/tests/__snapshot__/job_test.yaml.snap
+++ b/charts/mycarrier-helm/tests/__snapshot__/job_test.yaml.snap
@@ -1,0 +1,18 @@
+should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard):
+  1: |
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-options: Prune=true,Replace=true
+    vault.security.banzaicloud.io/mutate-probes: "true"
+    vault.security.banzaicloud.io/run-as-group: "1000"
+    vault.security.banzaicloud.io/run-as-non-root: "true"
+    vault.security.banzaicloud.io/run-as-user: "100"
+    vault.security.banzaicloud.io/vault-addr: https://vault.mycarrier.tech
+    vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+    vault.security.banzaicloud.io/vault-auth-method: azure
+    vault.security.banzaicloud.io/vault-env-daemon: "true"
+    vault.security.banzaicloud.io/vault-path: clusterauth
+    vault.security.banzaicloud.io/vault-role: appcluster
+  2: |
+    runAsGroup: 3000
+    runAsNonRoot: true
+    runAsUser: 1000

--- a/charts/mycarrier-helm/tests/__snapshot__/security_context_test.yaml.snap
+++ b/charts/mycarrier-helm/tests/__snapshot__/security_context_test.yaml.snap
@@ -1,0 +1,19 @@
+should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard):
+  1: |
+    mycarrier.io/gateway: istio-system/default
+    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    sidecar.istio.io/inject: "true"
+    vault.security.banzaicloud.io/mutate-probes: "true"
+    vault.security.banzaicloud.io/run-as-group: "1000"
+    vault.security.banzaicloud.io/run-as-non-root: "true"
+    vault.security.banzaicloud.io/run-as-user: "100"
+    vault.security.banzaicloud.io/vault-addr: https://vault.mycarrier.tech
+    vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+    vault.security.banzaicloud.io/vault-auth-method: azure
+    vault.security.banzaicloud.io/vault-env-daemon: "true"
+    vault.security.banzaicloud.io/vault-path: clusterauth
+    vault.security.banzaicloud.io/vault-role: appcluster
+  2: |
+    runAsGroup: 3000
+    runAsNonRoot: true
+    runAsUser: 1000

--- a/charts/mycarrier-helm/tests/cronjob_test.yaml
+++ b/charts/mycarrier-helm/tests/cronjob_test.yaml
@@ -923,3 +923,42 @@ tests:
           path: spec.jobTemplate.spec.template.metadata.annotations
       - matchSnapshot:
           path: spec.jobTemplate.spec.template.spec.securityContext
+
+  - it: should render the smallest legal fsGroup (1) as a presence guard boundary, not a falsey-guard boundary
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 1
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.fsGroup
+          value: 1
+
+  - it: should render pod securityContext with only the default fields when no cronjob securityContext is specified (opt-in regression guard)
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            runAsUser: 1000
+            runAsGroup: 3000
+            runAsNonRoot: true

--- a/charts/mycarrier-helm/tests/cronjob_test.yaml
+++ b/charts/mycarrier-helm/tests/cronjob_test.yaml
@@ -743,3 +743,183 @@ tests:
           content:
             secretRef:
               name: "backup-secrets"
+
+  - it: should render a large fsGroup value as a plain integer, not scientific notation (int64 cast regression guard)
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 1000000
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.fsGroup
+          value: 1000000
+
+  - it: should set container-level readOnlyRootFilesystem when specified on cronjob securityContext
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          securityContext:
+            readOnlyRootFilesystem: true
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should default container-level readOnlyRootFilesystem to false without cronjob securityContext
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false
+
+  - it: should set pod-level seccompProfile when specified on cronjob securityContext
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should let the chart-managed vault annotation win over a colliding user annotation while passing through a benign one
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          annotations:
+            sidecar.istio.io/inject: "false"
+            vault.security.banzaicloud.io/run-as-non-root: "false"
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["vault.security.banzaicloud.io/run-as-non-root"]
+          value: "true"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+      # Prove there is no duplicate/stray key left behind by the collision-drop logic: the plugin
+      # (v1.0.0) has no raw-text/duplicate-key assertion for parsed YAML manifests (matchRegexRaw
+      # only populates for text-file templates and render-error content, not standard K8s
+      # manifests - verified empirically: the "raw" field is nil for cronjob.yaml). The strongest
+      # available proxy is asserting the annotations map equals EXACTLY the expected key set -
+      # any duplicate key would either fail YAML decoding or be silently collapsed by the decoder,
+      # and any stray/incorrectly-retained key would break this exact-equality check.
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations
+          value:
+            sidecar.istio.io/inject: "false"
+            vault.security.banzaicloud.io/mutate-probes: "true"
+            vault.security.banzaicloud.io/run-as-group: "1000"
+            vault.security.banzaicloud.io/run-as-non-root: "true"
+            vault.security.banzaicloud.io/run-as-user: "100"
+            vault.security.banzaicloud.io/vault-addr: "https://vault.mycarrier.tech"
+            vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+            vault.security.banzaicloud.io/vault-auth-method: "azure"
+            vault.security.banzaicloud.io/vault-env-daemon: "true"
+            vault.security.banzaicloud.io/vault-path: "clusterauth"
+            vault.security.banzaicloud.io/vault-role: "appcluster"
+
+  - it: should let the chart-managed argocd sync-options annotation win over a colliding user annotation on CronJob metadata
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          annotations:
+            argocd.argoproj.io/sync-options: "Prune=false"
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "Prune=true"
+
+  - it: should reject fsGroup 0 via the values schema (fsGroup 0 is the root group and is disallowed)
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 0
+    asserts:
+      # Asserted loosely on purpose: the local unittest plugin (v1.0.0) emits
+      # "cronjobs.0.securityContext.fsGroup: Must be greater than or equal to 1", but CI pins
+      # v1.1.0 whose exact wording is unconfirmed. Two independent, version-robust patterns:
+      # one anchors on the field name, the other on the numeric bound/phrase, so this survives
+      # a wording change (e.g. jsonschema's "minimum: got 0, want 1" style) without being so loose
+      # it would also pass for an unrelated failure.
+      - failedTemplate:
+          errorPattern: "fsGroup"
+      - failedTemplate:
+          errorPattern: "(?i)(greater than or equal to 1|minimum|want 1|>= *1)"
+
+  - it: should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard)
+    set:
+      environment.name: "dev"
+      cronjobs:
+        - name: backup-job
+          schedule: "0 2 * * *"
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/backup"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: CronJob
+      - matchSnapshot:
+          path: spec.jobTemplate.spec.template.metadata.annotations
+      - matchSnapshot:
+          path: spec.jobTemplate.spec.template.spec.securityContext

--- a/charts/mycarrier-helm/tests/deployment_test.yaml
+++ b/charts/mycarrier-helm/tests/deployment_test.yaml
@@ -96,3 +96,62 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should let chart-managed pod-template annotations win over colliding user annotations on every reserved surface while passing a benign one through
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.annotations:
+        vault.security.banzaicloud.io/run-as-non-root: "false"
+        sidecar.istio.io/inject: "false"
+        mycarrier.io/gateway: "x/y"
+        team: "platform"
+    asserts:
+      - isKind:
+          of: Deployment
+      # Full-map equal (not contains) so drift in the reserved-key set or a surviving user
+      # override on any one of the four chart-managed keys (vault, istio inject, istio proxy
+      # config, gateway) fails this test - a contains assertion would not catch that.
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            vault.security.banzaicloud.io/vault-addr: "https://vault.mycarrier.tech"
+            vault.security.banzaicloud.io/mutate-probes: "true"
+            vault.security.banzaicloud.io/vault-auth-method: "azure"
+            vault.security.banzaicloud.io/vault-path: "clusterauth"
+            vault.security.banzaicloud.io/vault-role: "appcluster"
+            vault.security.banzaicloud.io/run-as-non-root: "true"
+            vault.security.banzaicloud.io/run-as-user: "100"
+            vault.security.banzaicloud.io/run-as-group: "1000"
+            vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+            vault.security.banzaicloud.io/vault-env-daemon: "true"
+            proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+            sidecar.istio.io/inject: "true"
+            mycarrier.io/gateway: "istio-system/default"
+            team: "platform"
+
+  - it: should still render sidecar.istio.io/inject false via istioDisabled after closing the annotation override (capability preserved)
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: deployment
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.env: {}
+      applications.test-app-api.istioDisabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+      - notExists:
+          path: spec.template.metadata.annotations["proxy.istio.io/config"]

--- a/charts/mycarrier-helm/tests/job_test.yaml
+++ b/charts/mycarrier-helm/tests/job_test.yaml
@@ -713,3 +713,133 @@ tests:
           content:
             name: tmp-dir
             mountPath: /tmp
+
+  - it: should render a large fsGroup value as a plain integer, not scientific notation (int64 cast regression guard)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 1000000
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000000
+
+  - it: should set container-level readOnlyRootFilesystem when specified on job securityContext
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            readOnlyRootFilesystem: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should default container-level readOnlyRootFilesystem to false without job securityContext
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false
+
+  - it: should set pod-level seccompProfile when specified on job securityContext
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should render pod securityContext with only the default fields when no job securityContext is specified (opt-in regression guard)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 1000
+            runAsGroup: 3000
+            runAsNonRoot: true
+
+  - it: should reject fsGroup 0 via the values schema (fsGroup 0 is the root group and is disallowed)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 0
+    asserts:
+      # Asserted loosely on purpose: the local unittest plugin (v1.0.0) emits
+      # "jobs.0.securityContext.fsGroup: Must be greater than or equal to 1", but CI pins
+      # v1.1.0 whose exact wording is unconfirmed. Two independent, version-robust patterns:
+      # one anchors on the field name, the other on the numeric bound/phrase, so this survives
+      # a wording change (e.g. jsonschema's "minimum: got 0, want 1" style) without being so loose
+      # it would also pass for an unrelated failure.
+      - failedTemplate:
+          errorPattern: "fsGroup"
+      - failedTemplate:
+          errorPattern: "(?i)(greater than or equal to 1|minimum|want 1|>= *1)"
+
+  - it: should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Job
+      - matchSnapshot:
+          path: spec.template.metadata.annotations
+      - matchSnapshot:
+          path: spec.template.spec.securityContext

--- a/charts/mycarrier-helm/tests/job_test.yaml
+++ b/charts/mycarrier-helm/tests/job_test.yaml
@@ -843,3 +843,161 @@ tests:
           path: spec.template.metadata.annotations
       - matchSnapshot:
           path: spec.template.spec.securityContext
+
+  - it: should let the chart-managed argocd sync-options annotation win over a colliding user annotation on Job metadata (exactly once, no stray duplicate)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          annotations:
+            argocd.argoproj.io/sync-options: "Prune=false"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "Force=true,Replace=true"
+
+  - it: should render jobs[].annotations onto the pod template too, with chart-managed keys winning over collisions (new capability)
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          annotations:
+            sidecar.istio.io/inject: "false"
+            argocd.argoproj.io/sync-options: "Prune=false"
+            vault.security.banzaicloud.io/run-as-non-root: "false"
+    asserts:
+      - isKind:
+          of: Job
+      # New capability: jobs[].annotations previously could not reach the pod template at all.
+      - equal:
+          path: spec.template.metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+      # Job pod-template sync-options differs from the Job-metadata value by design
+      # (Prune=true,Replace=true vs Force=true,Replace=true) - the collision must resolve to
+      # THIS surface's chart-managed value, not the metadata one.
+      - equal:
+          path: spec.template.metadata.annotations["argocd.argoproj.io/sync-options"]
+          value: "Prune=true,Replace=true"
+      - equal:
+          path: spec.template.metadata.annotations["vault.security.banzaicloud.io/run-as-non-root"]
+          value: "true"
+
+  - it: should reserve the argocd hook annotations on the job pod template unconditionally, even when timing is not set
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: regular-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/regular"
+            tag: "1.0.0"
+          annotations:
+            argocd.argoproj.io/hook: "PreSync"
+            argocd.argoproj.io/sync-wave: "5"
+    asserts:
+      - isKind:
+          of: Job
+      # No .job.timing set, so the chart itself would not render these keys - but they are
+      # reserved unconditionally (see _spec_job.tpl $argocdReserved), so the user-supplied
+      # values must still be dropped rather than leaking through.
+      - notExists:
+          path: spec.template.metadata.annotations["argocd.argoproj.io/hook"]
+      - notExists:
+          path: spec.template.metadata.annotations["argocd.argoproj.io/sync-wave"]
+
+  - it: should reject readOnlyRootFileSystem (capital S typo) via the values schema
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            readOnlyRootFileSystem: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "(?i)(readOnlyRootFileSystem|additional propert)"
+
+  - it: should reject an empty seccompProfile (missing required type) via the values schema
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            seccompProfile: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "(?i)(seccompProfile|missing propert|required)"
+
+  - it: should reject a seccompProfile.type outside the enum via the values schema
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            seccompProfile:
+              type: Bogus
+    asserts:
+      - failedTemplate:
+          errorPattern: "(?i)(RuntimeDefault|Localhost|Unconfined|enum|one of)"
+
+  - it: should set pod-level seccompProfile Localhost with a localhostProfile path
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            seccompProfile:
+              type: Localhost
+              localhostProfile: profiles/x.json
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: Localhost
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.localhostProfile
+          value: profiles/x.json
+
+  - it: should render the smallest legal fsGroup (1) as a presence guard boundary, not a falsey-guard boundary
+    set:
+      environment.name: "dev"
+      jobs:
+        - name: migration-job
+          image:
+            registry: "myregistry.example.com"
+            repository: "mycarrier/migration"
+            tag: "1.0.0"
+          securityContext:
+            fsGroup: 1
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1

--- a/charts/mycarrier-helm/tests/rollout_test.yaml
+++ b/charts/mycarrier-helm/tests/rollout_test.yaml
@@ -136,3 +136,29 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should honor application-level securityContext fsGroup and seccompProfile on the pod spec
+    set:
+      environment.name: "dev"
+      applications.app-level-sc-rollout:
+        enabled: true
+        deploymentType: rollout
+        image:
+          registry: "myregistry.example.com"
+          repository: "mycarrier/app-level-sc-rollout"
+          tag: "1.0.0"
+        updateStrategy:
+          type: "RollingUpdate"
+        securityContext:
+          fsGroup: 1000000
+          seccompProfile:
+            type: RuntimeDefault
+    asserts:
+      - isKind:
+          of: Rollout
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -151,3 +151,45 @@ tests:
           value:
             - NET_BIND_SERVICE
             - SYS_TIME
+
+  - it: should honor application-level securityContext fsGroup and seccompProfile on the pod spec
+    set:
+      environment.name: "dev"
+      applications.app-level-sc-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "app-level-sc-app"
+          tag: "1.0.0"
+        securityContext:
+          fsGroup: 1000000
+          seccompProfile:
+            type: RuntimeDefault
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should render pod-template annotations and pod securityContext byte-identical to snapshot (regression guard)
+    set:
+      environment.name: "dev"
+      applications.snapshot-guard-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "snapshot-guard-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchSnapshot:
+          path: spec.template.metadata.annotations
+      - matchSnapshot:
+          path: spec.template.spec.securityContext

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -193,3 +193,63 @@ tests:
           path: spec.template.metadata.annotations
       - matchSnapshot:
           path: spec.template.spec.securityContext
+
+  - it: should reject fsGroup 0 via the values schema on the application securityContext (fsGroup 0 is the root group and is disallowed)
+    set:
+      environment.name: "dev"
+      applications.fsgroup-zero-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "fsgroup-zero-app"
+          tag: "1.0.0"
+        securityContext:
+          fsGroup: 0
+    asserts:
+      # Loosely asserted for CI-version robustness (see the equivalent job/cronjob tests):
+      # local unittest v1.0.0 emits "Must be greater than or equal to 1"; CI pins v1.1.0 whose
+      # exact wording is unconfirmed - jsonschema's "minimum: got 0, want 1" is one known form.
+      - failedTemplate:
+          errorPattern: "fsGroup"
+      - failedTemplate:
+          errorPattern: "(?i)(greater than or equal to 1|minimum|want 1|>= *1)"
+
+  - it: should render the smallest legal fsGroup (1) on an application as a presence guard boundary, not a falsey-guard boundary
+    set:
+      environment.name: "dev"
+      applications.fsgroup-one-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "fsgroup-one-app"
+          tag: "1.0.0"
+        securityContext:
+          fsGroup: 1
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1
+
+  - it: should render pod securityContext with only the default fields when no application securityContext is specified (opt-in regression guard)
+    set:
+      environment.name: "dev"
+      applications.no-sc-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "no-sc-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 1000
+            runAsGroup: 3000
+            runAsNonRoot: true

--- a/charts/mycarrier-helm/tests/statefulset_test.yaml
+++ b/charts/mycarrier-helm/tests/statefulset_test.yaml
@@ -126,3 +126,27 @@ tests:
           path: spec.template.spec.volumes
       - exists:
           path: spec.template.spec.containers[0].volumeMounts
+
+  - it: should honor application-level securityContext fsGroup and seccompProfile on the pod spec
+    set:
+      environment.name: "dev"
+      applications.app-level-sc-statefulset:
+        enabled: true
+        deploymentType: statefulset
+        image:
+          registry: "myregistry.example.com"
+          repository: "mycarrier/app-level-sc-statefulset"
+          tag: "1.0.0"
+        securityContext:
+          fsGroup: 1000000
+          seccompProfile:
+            type: RuntimeDefault
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault

--- a/charts/mycarrier-helm/tests/statefulset_test.yaml
+++ b/charts/mycarrier-helm/tests/statefulset_test.yaml
@@ -150,3 +150,40 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault
+
+  - it: should let chart-managed pod-template annotations win over colliding user annotations on every reserved surface while passing a benign one through
+    set:
+      environment.name: "dev"
+      applications.test-app-api.deploymentType: statefulset
+      applications.test-app-api.isFrontend: false
+      applications.test-app-api.image.registry: "myregistry.example.com"
+      applications.test-app-api.image.repository: "mycarrier/test-app-api"
+      applications.test-app-api.image.tag: "1.0.0"
+      applications.test-app-api.ports.http: 8080
+      applications.test-app-api.annotations:
+        vault.security.banzaicloud.io/run-as-non-root: "false"
+        sidecar.istio.io/inject: "false"
+        mycarrier.io/gateway: "x/y"
+        team: "platform"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      # Full-map equal (not contains) so a surviving user override on any one of the four
+      # chart-managed keys would fail this test - a contains assertion would not catch that.
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            vault.security.banzaicloud.io/vault-addr: "https://vault.mycarrier.tech"
+            vault.security.banzaicloud.io/mutate-probes: "true"
+            vault.security.banzaicloud.io/vault-auth-method: "azure"
+            vault.security.banzaicloud.io/vault-path: "clusterauth"
+            vault.security.banzaicloud.io/vault-role: "appcluster"
+            vault.security.banzaicloud.io/run-as-non-root: "true"
+            vault.security.banzaicloud.io/run-as-user: "100"
+            vault.security.banzaicloud.io/run-as-group: "1000"
+            vault.security.banzaicloud.io/vault-agent-env-variables: '[{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]'
+            vault.security.banzaicloud.io/vault-env-daemon: "true"
+            proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+            sidecar.istio.io/inject: "true"
+            mycarrier.io/gateway: "istio-system/default"
+            team: "platform"

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -606,7 +606,8 @@
               },
               "fsGroup": {
                 "type": "integer",
-                "description": "Pod-level fsGroup (opt-in; unset by default)"
+                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
+                "minimum": 1
               },
               "seccompProfile": {
                 "type": "object",
@@ -1988,7 +1989,8 @@
               },
               "fsGroup": {
                 "type": "integer",
-                "description": "Pod-level fsGroup (opt-in; unset by default)"
+                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
+                "minimum": 1
               },
               "seccompProfile": {
                 "type": "object",

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -1726,6 +1726,26 @@
                 }
               }
             }
+          },
+          "securityContext": {
+            "type": "object",
+            "description": "Opt-in hardened security context for this job",
+            "properties": {
+              "readOnlyRootFilesystem": {
+                "type": "boolean",
+                "description": "Container-level readOnlyRootFilesystem (opt-in; unset defaults to false)",
+                "default": false
+              },
+              "fsGroup": {
+                "type": "integer",
+                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
+                "minimum": 1
+              },
+              "seccompProfile": {
+                "type": "object",
+                "description": "Pod-level seccompProfile (opt-in; unset by default)"
+              }
+            }
           }
         }
       }

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -169,6 +169,18 @@
               }
             ]
           },
+          "istioDisabled": {
+            "oneOf": [
+              {
+                "type": "boolean",
+                "description": "Opt this application's pod template out of Istio sidecar injection and drop the mycarrier.io/gateway annotation (read by _helpers.tpl helm.annotations.istio / helm.annotations.gateway). Not to be confused with service.istioDisabled, which is a separate per-service knob.",
+                "default": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "staticHostname": {
             "oneOf": [
               {
@@ -598,22 +610,7 @@
             }
           },
           "securityContext": {
-            "type": "object",
-            "properties": {
-              "readOnlyRootFilesystem": {
-                "type": "boolean",
-                "default": false
-              },
-              "fsGroup": {
-                "type": "integer",
-                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
-                "minimum": 1
-              },
-              "seccompProfile": {
-                "type": "object",
-                "description": "Pod-level seccompProfile (opt-in; unset by default)"
-              }
-            }
+            "$ref": "#/definitions/workloadSecurityContext"
           },
           "replicas": {
             "type": "integer",
@@ -1728,24 +1725,7 @@
             }
           },
           "securityContext": {
-            "type": "object",
-            "description": "Opt-in hardened security context for this job",
-            "properties": {
-              "readOnlyRootFilesystem": {
-                "type": "boolean",
-                "description": "Container-level readOnlyRootFilesystem (opt-in; unset defaults to false)",
-                "default": false
-              },
-              "fsGroup": {
-                "type": "integer",
-                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
-                "minimum": 1
-              },
-              "seccompProfile": {
-                "type": "object",
-                "description": "Pod-level seccompProfile (opt-in; unset by default)"
-              }
-            }
+            "$ref": "#/definitions/workloadSecurityContext"
           }
         }
       }
@@ -1999,24 +1979,7 @@
             }
           },
           "securityContext": {
-            "type": "object",
-            "description": "Opt-in hardened security context for this cronjob",
-            "properties": {
-              "readOnlyRootFilesystem": {
-                "type": "boolean",
-                "description": "Container-level readOnlyRootFilesystem (opt-in; unset defaults to false)",
-                "default": false
-              },
-              "fsGroup": {
-                "type": "integer",
-                "description": "Pod-level fsGroup (opt-in; unset by default; must be >= 1 — fsGroup 0 is the root group and is rejected)",
-                "minimum": 1
-              },
-              "seccompProfile": {
-                "type": "object",
-                "description": "Pod-level seccompProfile (opt-in; unset by default)"
-              }
-            }
+            "$ref": "#/definitions/workloadSecurityContext"
           }
         }
       }
@@ -2428,6 +2391,48 @@
                 }
               }
             }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "workloadSecurityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "description": "Container-level readOnlyRootFilesystem (opt-in; unset defaults to false)",
+          "default": false
+        },
+        "fsGroup": {
+          "type": "integer",
+          "description": "Pod-level fsGroup (opt-in; unset by default). Must be empty or greater than zero per MyCarrier-DevOps/kyverno-policies `require-non-root-groups` rule `check-fsGroup` — fsGroup 0 is the root group.",
+          "minimum": 1
+        },
+        "seccompProfile": {
+          "type": "object",
+          "description": "Pod-level seccompProfile (opt-in; unset by default)",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "SeccompProfile type, per the Kubernetes SeccompProfile.type API field",
+              "enum": ["RuntimeDefault", "Localhost", "Unconfined"]
+            },
+            "localhostProfile": {
+              "type": "string",
+              "description": "Path to a pre-configured profile on the node, relative to the kubelet's configured seccomp profile location. Only used when type is Localhost."
+            }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
+        "addCapabilities": {
+          "type": "array",
+          "description": "Linux capabilities to add back on top of the drop-all default. All capabilities are dropped by default; list ones here to add them back. Only honoured on the application (Deployment) path by _podsecurity.tpl — jobs and cronjobs do not read this field.",
+          "items": {
+            "type": "string"
           }
         }
       }

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -109,12 +109,44 @@ deployment: deployment
 ## **Container**: image.registry, image.repository, image.tag, pullPolicy, pullSecret
 ## **Resources**: resources.requests.cpu/memory, resources.limits.cpu/memory
 ## **Health Probes**: probes.enableLiveness, probes.enableReadiness, probes.enableStartup (all default true; set to false to disable), custom probe configurations
-## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back), securityContext.fsGroup (opt-in pod-level fsGroup; previously ignored/silently dropped, now honored; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema), securityContext.seccompProfile (opt-in pod-level seccompProfile; previously ignored/silently dropped, now honored)
+## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back), securityContext.fsGroup (opt-in pod-level fsGroup; previously ignored/silently dropped, now honored; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema; the >= 1 bound is ORG POLICY enforced by MyCarrier-DevOps/kyverno-policies `require-non-root-groups` rule `check-fsGroup` ("must be empty or greater than zero"), not an upstream Pod Security Standards control — the PSS spec contains zero occurrences of fsGroup/runAsGroup/supplementalGroups; those were PodSecurityPolicy fields, and PSP is retired), securityContext.seccompProfile (opt-in pod-level seccompProfile; previously ignored/silently dropped, now honored)
 ## **Service**: service.type, service.ports, service.annotations, service.timeout, service.retryOn
 ## **Networking**: networking.ingress.type, networking.istio.enabled/hosts/routes/corsPolicy/allowedEndpoints
 ## **Autoscaling**: HPA (autoscaling.minReplicas/maxReplicas/targetCPU/targetMemory), VPA (vpa.enabled/updateMode/resources)
 ## **Monitoring**: serviceMonitor.enabled/path/interval/scheme
 ## **Testing**: testtrigger configuration for automated test jobs
+##
+## **Annotations — reserved keys (application pod template)**: `applications[].annotations` render
+## onto the pod template for Deployment / StatefulSet / Rollout applications. Chart-managed
+## annotations always win: a user-supplied key that collides with a chart-managed key is DROPPED
+## from `annotations` before rendering — it does not override the chart's value and does not render
+## twice. The reserved set is an EXACT-KEY match (`hasKey`), not a `vault.security.banzaicloud.io/*`
+## prefix match:
+##   - vault keys: `vault-addr`, `vault-auth-method`, `vault-path`, `vault-role`,
+##     `vault-agent-env-variables`, `mutate-probes`, `run-as-non-root`, `run-as-user`,
+##     `run-as-group`, plus `vault-env-daemon` (only when `secrets` is set) and
+##     `vault-env-from-path` (only when `secrets.bulk.path` is set)
+##   - otel keys: `sidecar.opentelemetry.io/inject`, `instrumentation.opentelemetry.io/container-names`,
+##     and `instrumentation.opentelemetry.io/inject-<language>` for the ONE resolved language only.
+##     Rendered only when `manualOtelConfig` is not true AND `disableOtelAutoinstrumentation: false`
+##     AND the language is nodejs/java/python (verified call chain: `helm.otel.annotations` ->
+##     `helm.otel.autoinstrumentation.enabled` -> `helm.otel.chartManaged` -> `manualOtelConfig`)
+##   - istio keys: `sidecar.istio.io/inject`, `proxy.istio.io/config`
+##   - gateway key: `mycarrier.io/gateway`
+##
+## Any key NOT in this reserved set is applied to the pod as-is — including other
+## `vault.security.banzaicloud.io/*` keys the chart does not set. Security-relevant keys verified to
+## pass through unmanaged: `vault-skip-verify` (disables TLS verification to Vault), `mutate: skip`
+## (disables secret injection entirely), `vault-namespace`, `vault-serviceaccount`.
+## `psp-allow-privilege-escalation` also renders through but is not documented in the current
+## bank-vaults reference.
+##
+## **Istio override is CLOSED on application surfaces**: `sidecar.istio.io/inject`,
+## `proxy.istio.io/config` and `mycarrier.io/gateway` set in `applications[].annotations` are DROPPED
+## — the chart's own computed values always win. The supported per-workload knobs are
+## `applications[].istioDisabled`, `applications[].networking.istio.enabled`, and
+## `applications[].service.istioDisabled`. This closure does NOT apply to `cronjobs[]`/`jobs[]` — see
+## the Kubernetes Jobs / CronJobs sections below.
 
 ## @param applications [object] Map of application definitions where the key is the application name
 
@@ -593,14 +625,49 @@ applications: {}
 ##
 ## **Security Context (opt-in)**: securityContext.readOnlyRootFilesystem (default false; sets the
 ## container's readOnlyRootFilesystem), securityContext.fsGroup (unset by default; sets the pod-level
-## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema),
-## securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
-## {type: RuntimeDefault}). All three are opt-in per job item — omitting securityContext entirely
-## preserves the chart's existing default rendering.
+## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema; the >= 1
+## bound is ORG POLICY enforced by MyCarrier-DevOps/kyverno-policies `require-non-root-groups` rule
+## `check-fsGroup` ("must be empty or greater than zero"), not an upstream Pod Security Standards
+## control — the PSS spec contains zero occurrences of fsGroup/runAsGroup/supplementalGroups; those
+## were PodSecurityPolicy fields, and PSP is retired), securityContext.seccompProfile (unset by
+## default; sets the pod-level seccompProfile, e.g. {type: RuntimeDefault}). All three are opt-in per
+## job item — omitting securityContext entirely preserves the chart's existing default rendering.
 ##
-## IMPORTANT: the cluster's kyverno `restrict-seccomp` policy is Enforce and only allows
-## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
-## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
+## the `restrict-seccomp` ClusterPolicy differs per cluster, because each app cluster syncs its own
+## branch of MyCarrier-DevOps/kyverno-policies:
+##   - development cluster: validationFailureAction Enforce; pattern accepts
+##     `runtime/default | RuntimeDefault`, so `RuntimeDefault` passes and IS enforced at admission.
+##   - data and production-csp clusters: validationFailureAction Audit (report-only — violations
+##     appear in PolicyReport objects, nothing is blocked); pattern accepts only the literal
+##     `runtime/default`, so `RuntimeDefault` records a PolicyReport entry but is not rejected.
+## Use `RuntimeDefault`: it is the correct value for the Kubernetes SeccompProfile.type field
+## (`runtime/default` is the pre-1.25 annotation form and is not a legal field value), and Pod
+## Security Standards `restricted` permits `RuntimeDefault` and `Localhost`, forbidding only
+## `Unconfined`.
+##
+## **Annotations**: `jobs[].annotations` render onto BOTH the Job resource metadata and the Job pod
+## template (filtered), mirroring `cronjobs[].annotations`. This matters because chart Jobs are
+## ArgoCD PreSync/PostSync hooks — a never-exiting Istio sidecar on a Job pod blocks the entire
+## application sync, not just one Job run — so `sidecar.istio.io/inject: "false"` set via
+## `jobs[].annotations` is the documented way to stop that. The Job pod template emits no istio
+## annotations of its own, so this key is not chart-managed there and passes through unaffected
+## (unlike the application pod template, where it is chart-managed and closed to overrides).
+##
+## Chart-managed annotations always win; a colliding user-supplied key is DROPPED from `annotations`
+## before rendering. The reserved set is an EXACT-KEY match (`hasKey`), not a
+## `vault.security.banzaicloud.io/*` prefix match:
+##   - Job resource metadata: `argocd.argoproj.io/sync-options`
+##   - Job pod template: vault keys (`vault-addr`, `vault-auth-method`, `vault-path`, `vault-role`,
+##     `vault-agent-env-variables`, `mutate-probes`, `run-as-non-root`, `run-as-user`, `run-as-group`,
+##     plus `vault-env-daemon` when `secrets` is set and `vault-env-from-path` when
+##     `secrets.bulk.path` is set) and otel keys (`sidecar.opentelemetry.io/inject`,
+##     `instrumentation.opentelemetry.io/container-names`,
+##     `instrumentation.opentelemetry.io/inject-<language>` — see the Applications section above for
+##     the full otel gating conditions), plus `argocd.argoproj.io/sync-options`,
+##     `argocd.argoproj.io/hook-delete-policy`, `argocd.argoproj.io/sync-wave`, and
+##     `argocd.argoproj.io/hook`. The four argocd keys are reserved UNCONDITIONALLY, even though
+##     sync-wave/hook only render when `.timing` is set — this keeps the reserved set independent of
+##     `.timing`, so enabling a hook later cannot silently change which user keys survive.
 ##
 ## See the example configuration below for complete job specification details.
 
@@ -662,27 +729,51 @@ jobs: []
 ##
 ## **Security Context (opt-in)**: securityContext.readOnlyRootFilesystem (default false; sets the
 ## container's readOnlyRootFilesystem), securityContext.fsGroup (unset by default; sets the pod-level
-## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema),
-## securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
-## {type: RuntimeDefault}). All three are opt-in per cronjob item — omitting securityContext entirely
-## preserves the chart's existing default rendering.
+## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema; the >= 1
+## bound is ORG POLICY enforced by MyCarrier-DevOps/kyverno-policies `require-non-root-groups` rule
+## `check-fsGroup` ("must be empty or greater than zero"), not an upstream Pod Security Standards
+## control — the PSS spec contains zero occurrences of fsGroup/runAsGroup/supplementalGroups; those
+## were PodSecurityPolicy fields, and PSP is retired), securityContext.seccompProfile (unset by
+## default; sets the pod-level seccompProfile, e.g. {type: RuntimeDefault}). All three are opt-in per
+## cronjob item — omitting securityContext entirely preserves the chart's existing default rendering.
 ##
-## IMPORTANT: the cluster's kyverno `restrict-seccomp` policy is Enforce and only allows
-## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
-## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
+## the `restrict-seccomp` ClusterPolicy differs per cluster, because each app cluster syncs its own
+## branch of MyCarrier-DevOps/kyverno-policies:
+##   - development cluster: validationFailureAction Enforce; pattern accepts
+##     `runtime/default | RuntimeDefault`, so `RuntimeDefault` passes and IS enforced at admission.
+##   - data and production-csp clusters: validationFailureAction Audit (report-only — violations
+##     appear in PolicyReport objects, nothing is blocked); pattern accepts only the literal
+##     `runtime/default`, so `RuntimeDefault` records a PolicyReport entry but is not rejected.
+## Use `RuntimeDefault`: it is the correct value for the Kubernetes SeccompProfile.type field
+## (`runtime/default` is the pre-1.25 annotation form and is not a legal field value), and Pod
+## Security Standards `restricted` permits `RuntimeDefault` and `Localhost`, forbidding only
+## `Unconfined`.
 ##
 ## `annotations` render onto BOTH the CronJob resource metadata and the CronJob pod template, so it
 ## can be used to set per-cronjob pod annotations — e.g. `sidecar.istio.io/inject: "false"` to opt a
 ## CronJob's pods out of Istio sidecar injection in istio-injection=enabled namespaces (a never-exiting
-## sidecar container otherwise hangs the Job). `sidecar.istio.io/inject` is not chart-managed and
-## passes through unaffected.
+## sidecar container otherwise hangs the Job). The CronJob pod template emits no istio annotations of
+## its own, so `sidecar.istio.io/inject` is not chart-managed here and passes through unaffected —
+## unlike the application pod template, where this key IS chart-managed and closed to overrides.
 ##
 ## Chart-managed annotations always win. A user-supplied key that collides with a chart-managed
 ## annotation is DROPPED from `annotations` before rendering — it will not override the chart's value,
-## and it will not render twice. Chart-managed keys are: all `vault.security.banzaicloud.io/*` (pod
-## template), the otel keys `sidecar.opentelemetry.io/inject` and `instrumentation.opentelemetry.io/*`
-## (pod template, only when otel autoinstrumentation is enabled AND the app language is
-## nodejs/java/python), and `argocd.argoproj.io/sync-options` (CronJob metadata).
+## and it will not render twice. The reserved set is an EXACT-KEY match (`hasKey`), not a
+## `vault.security.banzaicloud.io/*` prefix match:
+##   - CronJob resource metadata: `argocd.argoproj.io/sync-options`
+##   - CronJob pod template: vault keys (`vault-addr`, `vault-auth-method`, `vault-path`, `vault-role`,
+##     `vault-agent-env-variables`, `mutate-probes`, `run-as-non-root`, `run-as-user`, `run-as-group`,
+##     plus `vault-env-daemon` when `secrets` is set and `vault-env-from-path` when
+##     `secrets.bulk.path` is set) and otel keys (`sidecar.opentelemetry.io/inject`,
+##     `instrumentation.opentelemetry.io/container-names`,
+##     `instrumentation.opentelemetry.io/inject-<language>` — see the Applications section above for
+##     the full otel gating conditions). No argocd/istio/gateway keys are reserved on the CronJob pod
+##     template.
+##
+## Any key NOT in the reserved set above is applied to the pod/resource as-is — including other
+## `vault.security.banzaicloud.io/*` keys the chart does not set (see the Applications section above
+## for the security-relevant passthrough keys verified: `vault-skip-verify`, `mutate: skip`,
+## `vault-namespace`, `vault-serviceaccount`, `psp-allow-privilege-escalation`).
 ##
 ## The reserved set is context-dependent: a key that is free today can become chart-managed when a
 ## related feature is enabled (e.g. turning on otel autoinstrumentation), at which point the user's

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -588,8 +588,20 @@ applications: {}
 ##
 ## Each job supports: name, timing (pre-deploy/post-deploy), order, ttlSecondsAfterFinished,
 ## activeDeadlineSeconds, backoffLimit, labels, annotations, image (registry/repository/tag),
-## imagePullPolicy, command, args, env, resources (requests/limits for cpu/memory)
-## 
+## imagePullPolicy, command, args, env, resources (requests/limits for cpu/memory), volumes,
+## securityContext (opt-in hardened security context, see below)
+##
+## **Security Context (opt-in)**: securityContext.readOnlyRootFilesystem (default false; sets the
+## container's readOnlyRootFilesystem), securityContext.fsGroup (unset by default; sets the pod-level
+## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema),
+## securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
+## {type: RuntimeDefault}). All three are opt-in per job item — omitting securityContext entirely
+## preserves the chart's existing default rendering.
+##
+## IMPORTANT: the cluster's kyverno `restrict-seccomp` policy is Enforce and only allows
+## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
+## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
+##
 ## See the example configuration below for complete job specification details.
 
 ## @param jobs [array] List of Kubernetes Jobs to run
@@ -631,6 +643,13 @@ jobs: []
 #     limits:
 #       cpu: "500m"
 #       memory: "256Mi"
+#
+#   # Optional: Hardened security context (opt-in; omit entirely to keep default rendering)
+#   # securityContext:
+#   #   readOnlyRootFilesystem: true
+#   #   fsGroup: 3000
+#   #   seccompProfile:
+#   #     type: RuntimeDefault
 
 ## @section Kubernetes CronJobs
 ## Configuration for Kubernetes CronJobs to run on a schedule

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -109,7 +109,7 @@ deployment: deployment
 ## **Container**: image.registry, image.repository, image.tag, pullPolicy, pullSecret
 ## **Resources**: resources.requests.cpu/memory, resources.limits.cpu/memory
 ## **Health Probes**: probes.enableLiveness, probes.enableReadiness, probes.enableStartup (all default true; set to false to disable), custom probe configurations
-## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back), securityContext.fsGroup (opt-in pod-level fsGroup; previously ignored/silently dropped, now honored), securityContext.seccompProfile (opt-in pod-level seccompProfile; previously ignored/silently dropped, now honored)
+## **Security Context**: securityContext.readOnlyRootFilesystem (default false), securityContext.addCapabilities (default []; all capabilities are dropped by default, list specific capabilities here to add them back), securityContext.fsGroup (opt-in pod-level fsGroup; previously ignored/silently dropped, now honored; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema), securityContext.seccompProfile (opt-in pod-level seccompProfile; previously ignored/silently dropped, now honored)
 ## **Service**: service.type, service.ports, service.annotations, service.timeout, service.retryOn
 ## **Networking**: networking.ingress.type, networking.istio.enabled/hosts/routes/corsPolicy/allowedEndpoints
 ## **Autoscaling**: HPA (autoscaling.minReplicas/maxReplicas/targetCPU/targetMemory), VPA (vpa.enabled/updateMode/resources)
@@ -643,7 +643,8 @@ jobs: []
 ##
 ## **Security Context (opt-in)**: securityContext.readOnlyRootFilesystem (default false; sets the
 ## container's readOnlyRootFilesystem), securityContext.fsGroup (unset by default; sets the pod-level
-## fsGroup), securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
+## fsGroup; must be >= 1 — fsGroup 0 is the root group and is rejected by the values schema),
+## securityContext.seccompProfile (unset by default; sets the pod-level seccompProfile, e.g.
 ## {type: RuntimeDefault}). All three are opt-in per cronjob item — omitting securityContext entirely
 ## preserves the chart's existing default rendering.
 ##
@@ -651,10 +652,23 @@ jobs: []
 ## seccompProfile.type `RuntimeDefault` (or `runtime/default`) — `Localhost` renders fine from this
 ## chart but is hard-rejected at admission. Stick to `RuntimeDefault`.
 ##
-## `annotations` now also render onto the CronJob pod template (in addition to the CronJob resource
-## itself), so it can be used to set per-cronjob pod annotations — e.g. `sidecar.istio.io/inject: "false"`
-## to opt a CronJob's pods out of Istio sidecar injection in istio-injection=enabled namespaces (a
-## never-exiting sidecar container otherwise hangs the Job).
+## `annotations` render onto BOTH the CronJob resource metadata and the CronJob pod template, so it
+## can be used to set per-cronjob pod annotations — e.g. `sidecar.istio.io/inject: "false"` to opt a
+## CronJob's pods out of Istio sidecar injection in istio-injection=enabled namespaces (a never-exiting
+## sidecar container otherwise hangs the Job). `sidecar.istio.io/inject` is not chart-managed and
+## passes through unaffected.
+##
+## Chart-managed annotations always win. A user-supplied key that collides with a chart-managed
+## annotation is DROPPED from `annotations` before rendering — it will not override the chart's value,
+## and it will not render twice. Chart-managed keys are: all `vault.security.banzaicloud.io/*` (pod
+## template), the otel keys `sidecar.opentelemetry.io/inject` and `instrumentation.opentelemetry.io/*`
+## (pod template, only when otel autoinstrumentation is enabled AND the app language is
+## nodejs/java/python), and `argocd.argoproj.io/sync-options` (CronJob metadata).
+##
+## The reserved set is context-dependent: a key that is free today can become chart-managed when a
+## related feature is enabled (e.g. turning on otel autoinstrumentation), at which point the user's
+## value stops taking effect. This is deliberate — the alternative (failing the template render) would
+## turn an unrelated future "enable otel" change into a hard non-local build break.
 ##
 ## See the example configuration below for complete cronjob specification details.
 


### PR DESCRIPTION
---
Follow-up to #110. That PR merged at `2026-08-07T13:18:03Z`; the CHANGES_REQUESTED review landed at `13:37:37Z`, 19 minutes later, so it could not be edited. Chart **3.5.7 is published on main and currently ships both defects**. This PR fixes them.

## Defect 1 — user annotations could render the same YAML key twice

Review comment: https://github.com/MyCarrier-DevOps/helm-charts/pull/110#discussion_r3736131377

In plain English: `cronjobs[].annotations` were pasted into the rendered manifest as text, *after* the chart's own vault and otel annotations. If your values file set a key the chart also sets, that key appeared **twice** in the same annotations map. kubectl and ArgoCD convert YAML to JSON with last-key-wins, so your value quietly took effect — including for the vault-secrets-webhook directives the chart otherwise pins (`run-as-non-root`, `run-as-user`, `mutate-probes`, `vault-path`). Nothing errored at template, schema, sync, or admission time.

The bigger practical problem is the duplicate key itself. A Trivy 0.61.0 config scan **silently skipped the entire rendered CronJob document** because of it; removing the duplicate made the same document scannable (99 checks). Duplicate keys make downstream scanners blind to everything else in the file.

### What changed

Chart-managed annotations now **always win**. A user key that collides with a chart-managed one is dropped before rendering — it does not override the chart, and it does not render twice. New helper `helm.annotations.userExtra` in `templates/_annotations.tpl` does the filtering; `helm.annotations.cronjobMetadata` exists so `cronjob.yaml` derives its reserved set from the same place it renders from, rather than hardcoding the key in two spots.

Chart-managed keys, scoped per annotation map:
- **Pod template**: all `vault.security.banzaicloud.io/*`, plus `sidecar.opentelemetry.io/inject` and `instrumentation.opentelemetry.io/*` (only when otel autoinstrumentation is on and the language is nodejs/java/python).
- **CronJob metadata**: `argocd.argoproj.io/sync-options`.

`sidecar.istio.io/inject` is not chart-managed and passes through untouched — that is the key the first real consumer actually uses.

### Why a merge and not the suggested `fail`

The review suggested failing the render on collision. I did not adopt that, for two reasons:

1. It is a breaking change for any values file that already carries a colliding key.
2. The reserved set is **context-dependent by design** — otel keys are reserved only when `disableOtelAutoinstrumentation` is false *and* the language matches; `vault-env-from-path` only when `secrets.bulk.path` is set. So a values file renders fine today and starts hard-failing the moment somebody enables an unrelated feature. That break would surface in a future "enable otel" PR, for reasons its author cannot see from their own diff.

A merge emits each key exactly once with an explicit, documented precedence. It fixes the silent override *and* the duplicate-key/scanner problem without planting that landmine. The precedence rule and the full reserved-key list are documented in `values.yaml`.

Blast radius was checked before choosing: across every values file in the org, the only cronjob annotation in use is `sidecar.istio.io/inject: "false"`, which is not chart-managed. **No existing consumer's render changes.**

### The CronJob-metadata surface

`cronjob.yaml` had the identical text-append bug, pre-existing on main. **Fixed here too**, deliberately: it is the same mechanism on the same resource, the Trivy skip is per-document so a metadata-level duplicate blinds the same file, and it reuses the helper already being added. Leaving it would have shipped a precedence rule that holds on only one of the resource's two annotation maps.

### Proof

Same values file, one cronjob whose annotations carry both a benign key and two colliding chart-managed keys:

```
=== BRANCH render, duplicate-key check ===
PASS: no duplicate keys across 1 document(s)          exit=0

=== MAIN render, same values, same check ===
FAIL: Duplicate key found: 'argocd.argoproj.io/sync-options'   exit=1
```

Rendered output, each key exactly once per map:

```yaml
  annotations:                                             # CronJob metadata
    argocd.argoproj.io/sync-options: Prune=true            # reserved here -> chart wins
    sidecar.istio.io/inject: "false"                       # passes through
    vault.security.banzaicloud.io/run-as-non-root: "false"
```
```yaml
          annotations:                                     # pod template
            vault.security.banzaicloud.io/vault-addr: "https://vault.mycarrier.tech"
            vault.security.banzaicloud.io/mutate-probes: "true"
            vault.security.banzaicloud.io/vault-auth-method: azure
            vault.security.banzaicloud.io/vault-path: clusterauth
            vault.security.banzaicloud.io/vault-role: appcluster
            vault.security.banzaicloud.io/run-as-non-root: "true"   # reserved here -> chart wins
            vault.security.banzaicloud.io/run-as-user: "100"
            vault.security.banzaicloud.io/run-as-group: "1000"
            vault.security.banzaicloud.io/vault-agent-env-variables: >-
              [{"Name":"SKIP_CHOWN","Value":"true"},{"Name":"SKIP_SETCAP","Value":"true"}]
            vault.security.banzaicloud.io/vault-env-daemon: "true"
            argocd.argoproj.io/sync-options: Prune=false
            sidecar.istio.io/inject: "false"
```

## Defect 2 — the new securityContext keys shipped untested

Review comment: https://github.com/MyCarrier-DevOps/helm-charts/pull/110#discussion_r3736131389

#110 added exactly one test, covering annotation placement. There was no coverage for `readOnlyRootFilesystem`, `fsGroup`, or `seccompProfile` on cronjobs, and none for the application path those keys had just gone live on.

The sharpest part: the `int64` cast that #110's description headlined as its reason for existing was **protected by nothing**. Confirmed by reproducing it before writing any test — strip `int64` from `_podsecurity.tpl` and `fsGroup: 1000000` renders as `fsGroup: 1e+06`, which the API server rejects, and **all 588 tests still passed**.

### What changed

12 tests added, 588 -> 600, 0 failures:

1. **int64 regression guard** — cronjob `fsGroup: 1000000`. Verified to actually bite by stripping the cast and watching it fail, then restoring:
   ```
   - asserts[1] `equal` fail
       Path:  spec.jobTemplate.spec.template.spec.securityContext.fsGroup
       Expected to equal: 1000000
       Actual: 1e+06
   ```
2. `readOnlyRootFilesystem: true` at container level, plus the negative case.
3. `seccompProfile: {type: RuntimeDefault}` at pod level.
4. Application-level `fsGroup` + `seccompProfile` reaching the Deployment pod spec, plus StatefulSet and Rollout. This pins the contract change — those keys were previously inert and are now honored.
5. Collision tests for Defect 1 on both annotation surfaces.
6. `fsGroup: 0` schema rejection.
7. Snapshot guards for the "default renders byte-identical" claim.

### `fsGroup: 0`

`{{- with $sc.fsGroup }}` treats `0` as falsey, so an explicitly-set `fsGroup: 0` was **silently dropped** — you asked for the root group and got nothing, with no signal. Now `"minimum": 1` in `values.schema.json` (on both the application and cronjob properties) turns it into an explicit rejection. The template guard is unchanged; with the bound in place `0` is unreachable, so the falsiness is no longer a silent-drop path.

The test asserts with `errorPattern` rather than an exact message, because the plugin's validator wording differs from helm's own and differs across plugin versions. The suite was then run under CI's pinned helm-unittest **v1.1.0**, so this is confirmed rather than assumed.

### Snapshot guard — and a `.gitignore` fix it needed

The snapshot tests were initially useless: repo `.gitignore` had a bare `__snapshot__` pattern, so baselines were never tracked. On a fresh CI clone helm-unittest silently regenerates the baseline and passes trivially — a guard that can only agree with itself. Added a narrow negation (`!charts/mycarrier-helm/tests/__snapshot__/`) leaving the broad rule intact, then proved the guard now bites by perturbing `vault-role` and watching both snapshot suites fail.

Worth flagging for anyone verifying locally: **helm-unittest v1.0.0 false-passes `matchSnapshot`** against a deliberately corrupted baseline. CI's pinned **v1.1.0** catches it. Use v1.1.0 for any local snapshot check.

## Defect 3 — job-level `securityContext` was a silent no-op

Found while validating the above, and pulled into this PR because it blocks kyverno policy enforcement.

`jobs.yaml` builds its context as `merge (dict "job" . "ctx" $globalCtx) $`, so per-item values land under the key `job`. But `helm.workloadSecurityContext` only read `.application` and `.cronjob`. Anything you set under `jobs[].securityContext` was therefore **silently discarded** — `fsGroup`, `seccompProfile` and `readOnlyRootFilesystem` never reached the rendered Job, and nothing errored to tell you. On top of that, the `jobs` item schema had no `securityContext` property at all, so there was no schema-level signal either.

That is what blocks kyverno: Jobs rendered by this chart cannot satisfy restricted pod-security policies while the hardening opt-ins do nothing.

Before and after, same job values (`fsGroup: 1000000`, `readOnlyRootFilesystem: true`, `seccompProfile: {type: RuntimeDefault}`):

```yaml
# before — pod-level securityContext on the rendered Job
      securityContext:
        runAsUser: 1000
        runAsGroup: 3000
        runAsNonRoot: true
```
```yaml
# after
      securityContext:
        runAsUser: 1000
        runAsGroup: 3000
        runAsNonRoot: true
        fsGroup: 1000000
        seccompProfile:
          type: RuntimeDefault
```

`_spec_job.tpl` needed no change — it already calls both helpers. The fix is the `.job` branch in the helper plus a `securityContext` block on the jobs item in `values.schema.json`, mirroring cronjobs including `"minimum": 1` on `fsGroup`.

`triggertestengine` was checked and is fine — it passes context key `application`, so it already worked. `job` was the only miswired key.

7 more tests (600 -> 607), including an **opt-in regression guard**: a job with no `securityContext` must render a pod securityContext of exactly `runAsUser`/`runAsGroup`/`runAsNonRoot` and nothing else, so a future change that starts emitting these unconditionally is caught.

Deliberate non-change: `helm.containerSecurityContext` still gates its `addCapabilities` escape hatch on `.application` only. Cronjobs don't get it either, so jobs matching cronjob behaviour is consistent.

## Validation

- `helm lint` — pass on both default and feature values.
- `helm unittest` — 59 suites, **607 tests**, 6 snapshots, **0 failures** (under CI's pinned v1.1.0).
- **Default render byte-identical vs `origin/main` across all six workload templates** that consume the shared helpers: deployment, jobs, rollout, statefulset, triggertestengine, cronjob. 6/6, compared via a clean worktree. Re-verified after the job-context fix, since that change touches the shared helper.

## Notes

- `Chart.yaml` is intentionally left at **3.5.7**. CI bumps it to **3.5.8** on merge.
- Pin sequencing: `workflow-core` currently pins `3.5.6` and `workflow-dev` already pins `3.5.7`. Plan is to move **both to 3.5.8** once this merges, rather than landing anything else on 3.5.7.



## Review round two

All 15 review threads addressed. Summary of what changed beyond the original scope:

- **Annotation filtering now covers every surface**, not just CronJob: the three application pod templates, Job resource metadata, and the Job pod template. `istio`/`gateway` keys are reserved on application surfaces too — `applications[].istioDisabled` and `networking.istio.enabled` are the supported knobs, and leaving the annotation open kept a live duplicate key.
- **`jobs[].annotations` now reach the Job pod template.** Previously impossible. Chart Jobs are ArgoCD PreSync/PostSync hooks, so a never-exiting Istio sidecar blocks the whole application sync.
- **Schema deduplicated and tightened**: one `#/definitions/workloadSecurityContext`, `additionalProperties: false`, `seccompProfile` requiring `type` against the three legal Kubernetes values, `addCapabilities` declared.
- **`_podsecurity.tpl`**: exclusive `else if` chain; presence-based `hasKey` guards.
- **Dead `| default dict` removed** from all seven reserved-set sites, replaced by one fail-fast guard that fires only on chart-authored parse failures.
- **Docs corrected**: reserved set is exact keys not a `vault.*` prefix; the kyverno `restrict-seccomp` note is now per-cluster accurate (Enforce on the development cluster accepting `RuntimeDefault`; Audit elsewhere accepting only `runtime/default`); `fsGroup >= 1` attributed to org policy, since Pod Security Standards does not constrain `fsGroup` at all.

Two suggestions were declined with evidence (the dict-refactor remedy, which breaks byte-identity; and `@param` entries, which the README generator rejects for array-item paths), and the kyverno finding was corrected against live cluster state. Details in the individual threads.

**Validation**: 59 suites, **623 tests** (+16), 6 snapshots, 0 failures. Default render byte-identical to main across all six workload templates. A values file engineered to collide on every annotation surface renders **zero duplicate YAML keys** on this branch; the same input on `main` produces three.
