### PR TITLE
Decouple readOnly hardening from dead enableVaultCA flag (DEVOPS-176)

### DIFF
--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1398,7 +1398,7 @@ When contributing to this chart, please follow the coding standards defined in t
 
 | Name                             | Description                                                                            | Value        |
 | -------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
-| `enableVaultCA`                  | Enable Vault CA certificate download during pod startup                                | `false`      |
+| `enableVaultCA`                  | Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code) | `false`      |
 | `manualOtelConfig`               | Take over OpenTelemetry configuration from the chart (default false = chart-managed)   | `false`      |
 | `disableOtelAutoinstrumentation` | Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)      | `true`       |
 | `tolerations`                    | Default tolerations for all applications                                               | `[]`         |

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -19,8 +19,15 @@ context only ever carries one of .application/.cronjob/.job.
 {{- $sc | toJson -}}
 {{- end -}}
 
+{{/*
+enableVaultCA no longer gates hardening here: its only other consumer,
+helm.defaultLifecyclePostStart's root-requiring vault.crt postStart hook, is
+dead code (helm.lifecycle, its sole caller, is fully commented out in
+_lifecycle.tpl). Kyverno require-run-as-non-root is Enforce on dev, so
+disableSecurity remains the sole explicit break-glass opt-out.
+*/}}
 {{- define "helm.podSecurityContext" -}}
-{{- if and (not .Values.enableVaultCA) (not .Values.disableSecurity) }}
+{{- if not .Values.disableSecurity }}
 {{- $sc := include "helm.workloadSecurityContext" . | fromJson }}
 securityContext:
   runAsUser: 1000
@@ -36,8 +43,15 @@ securityContext:
 {{- end }}
 {{- end -}}
 
+{{/*
+enableVaultCA no longer gates hardening here: its only other consumer,
+helm.defaultLifecyclePostStart's root-requiring vault.crt postStart hook, is
+dead code (helm.lifecycle, its sole caller, is fully commented out in
+_lifecycle.tpl). Kyverno require-run-as-non-root is Enforce on dev, so
+disableSecurity remains the sole explicit break-glass opt-out.
+*/}}
 {{- define "helm.containerSecurityContext" -}}
-{{- if and (not .Values.enableVaultCA) (not .Values.disableSecurity) }}
+{{- if not .Values.disableSecurity }}
 {{- $sc := include "helm.workloadSecurityContext" . | fromJson }}
 securityContext:
   runAsUser: 1000

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -253,3 +253,67 @@ tests:
             runAsUser: 1000
             runAsGroup: 3000
             runAsNonRoot: true
+
+  - it: should still harden pod and container securityContext when enableVaultCA is true (enableVaultCA no longer gates hardening; its only other consumer is dead code)
+    set:
+      environment.name: "dev"
+      enableVaultCA: true
+      applications.vault-ca-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "vault-ca-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should omit securityContext when disableSecurity is true, even if enableVaultCA is also true (break-glass opt-out is unchanged)
+    set:
+      environment.name: "dev"
+      enableVaultCA: true
+      disableSecurity: true
+      applications.disable-security-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "disable-security-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.securityContext
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should render pod and container securityContext unchanged when enableVaultCA and disableSecurity are both unset (default)
+    set:
+      environment.name: "dev"
+      applications.default-security-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "default-security-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 1000
+            runAsGroup: 3000
+            runAsNonRoot: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -67,7 +67,7 @@ environment:
 ## @section Platform Settings
 ## Platform-wide settings
 
-## @param enableVaultCA Enable Vault CA certificate download during pod startup
+## @param enableVaultCA Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code)
 ## @param manualOtelConfig Take over OpenTelemetry configuration from the chart (default false = chart-managed)
 ## @param disableOtelAutoinstrumentation Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)
 ## @param tolerations [array] Default tolerations for all applications


### PR DESCRIPTION
## Summary
- The `_podsecurity.tpl` security-context guard required `not enableVaultCA` in addition to `not disableSecurity`, so enabling `enableVaultCA` silently disabled `runAsNonRoot`/`readOnlyRootFilesystem` hardening.
- `enableVaultCA`'s only non-security consumer — the `vault.crt` / `update-ca-certificates` postStart hook wired through `helm.lifecycle` — is dead, fully-commented-out code in `_lifecycle.tpl`. The flag needlessly coupled a dead feature to a live security control.
- Guard is now `not disableSecurity` only; `disableSecurity` remains the sole explicit break-glass opt-out.
- Adds 3 helm-unittest regression cases: `enableVaultCA=true` (hardening still applies), `disableSecurity=true` with `enableVaultCA=true` (break-glass still works), and default/unset (render unchanged).
- Documents the behavior change in `values.yaml` and `README.md` param descriptions.

## Test plan
- [x] `helm unittest charts/mycarrier-helm` — 638/638 tests pass, 59/59 suites, 6/6 snapshots
- [x] `helm lint charts/mycarrier-helm` — 0 charts failed
- [x] New regression test confirms default (enableVaultCA/disableSecurity unset) render is unchanged
- [x] New regression test confirms `disableSecurity=true` remains the sole break-glass, even with `enableVaultCA=true`

Relates to bd homc (enableVaultCA guard removal audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)