### PR TITLE
feat(splitproxy): add /tmp emptyDir for readOnlyRootFilesystem (DEVOPS-176)

### DIFF
--- a/charts/splitproxy/Chart.yaml
+++ b/charts/splitproxy/Chart.yaml
@@ -3,4 +3,4 @@ name: splitproxy
 description: A Helm chart for splitproxy server and admin-dashboard
 type: application
 icon: https://www.split.io/wp-content/uploads/2017/11/split-logo-light-background-transparent.png
-version: 0.3.13
+version: 0.3.14

--- a/charts/splitproxy/templates/deployment.yaml
+++ b/charts/splitproxy/templates/deployment.yaml
@@ -100,23 +100,29 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: splitproxy
-                key: SplitDashboardPassword 
+                key: SplitDashboardPassword
+          {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.secretProvider.enabled }}
             - name:  secret-store
               mountPath:  "/mnt/secrets-store"
               readOnly: true
-          {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.secretProvider.enabled }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.secretProvider.enabled }}
         - name: secret-store
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ $.Values.secretProvider.name }}
-      {{- end }}  
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

- Adds an unconditional `/tmp` `emptyDir` volume + volumeMount to the splitproxy deployment template (the secret-store CSI volume mount stays conditional as before).
- Bumps the chart version from 0.3.13 to 0.3.14.

## Why

`split-proxy:5.5.1` writes a boltdb snapshot to `/tmp/splitio__<rand>.db` at startup. When `readOnlyRootFilesystem: true` is set and there's no writable `/tmp`, the container crashes with `EROFS` before it ever starts serving traffic. Mounting a small `/tmp` `emptyDir` gives the process somewhere writable regardless of the root filesystem setting, so the chart no longer breaks when consumers turn on `readOnlyRootFilesystem`.

The `readOnlyRootFilesystem` flag itself stays values-driven (plain securityContext passthrough) — this change only makes sure `/tmp` is writable *if* a consumer enables it. Nothing changes for consumers who don't set the flag.

## Proof

- `docker run --read-only splitproxy:5.5.1` → fails immediately: read-only file system error on boltdb open at `/tmp/splitio__*.db`.
- `docker run --read-only --tmpfs /tmp splitproxy:5.5.1` → starts clean, serves traffic, `docker diff` on the container is empty (no other filesystem writes outside `/tmp`).
- `helm lint charts/splitproxy` passes.
- Rendered the chart both with and without `secretProvider` configured, and with `readOnlyRootFilesystem: true` — the `/tmp` emptyDir mount is present in all cases, and the CSI secret mount only appears when `secretProvider` is set (unchanged behavior).

## Rollout

No behavior change for existing consumers — `readOnlyRootFilesystem` remains off by default, and the new `/tmp` mount is harmless whether or not the flag is set. A values bump to actually enable `readOnlyRootFilesystem: true` for dev-cluster environments will follow in a separate ManagementInfra PR.

Part of the same DEVOPS-176 series as #104 and #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)