### PR TITLE
docs(mycarrier-helm): document disableSecurity break-glass flag + schema entry

### DIFF
--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1399,6 +1399,7 @@ When contributing to this chart, please follow the coding standards defined in t
 | Name                             | Description                                                                            | Value        |
 | -------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
 | `enableVaultCA`                  | Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code) | `false`      |
+| `disableSecurity`                | BREAK-GLASS ONLY (discouraged). When true, pods render without runAsNonRoot/securityContext hardening — the sole remaining un-harden path after the enableVaultCA guard removal | `false`      |
 | `manualOtelConfig`               | Take over OpenTelemetry configuration from the chart (default false = chart-managed)   | `false`      |
 | `disableOtelAutoinstrumentation` | Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)      | `true`       |
 | `tolerations`                    | Default tolerations for all applications                                               | `[]`         |

--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1399,7 +1399,7 @@ When contributing to this chart, please follow the coding standards defined in t
 | Name                             | Description                                                                            | Value        |
 | -------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
 | `enableVaultCA`                  | Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code) | `false`      |
-| `disableSecurity`                | BREAK-GLASS ONLY (discouraged). When true, pods render without runAsNonRoot/securityContext hardening — the sole remaining un-harden path after the enableVaultCA guard removal | `false`      |
+| `disableSecurity`                | BREAK-GLASS ONLY (discouraged). When true, every pod in the release renders without runAsNonRoot/securityContext hardening — release-wide, cannot be scoped per-application. Only flag that removes the hardening block (`enableDebugMode`'s privileged sidecar is a separate route). Kyverno `require-run-as-non-root` is Enforce only on development (Audit on production-csp/data). Not settable through mc-environment `environments[]` — direct mycarrier-helm values only. | `false`      |
 | `manualOtelConfig`               | Take over OpenTelemetry configuration from the chart (default false = chart-managed)   | `false`      |
 | `disableOtelAutoinstrumentation` | Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)      | `true`       |
 | `tolerations`                    | Default tolerations for all applications                                               | `[]`         |

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -94,7 +94,7 @@
     },
     "disableSecurity": {
       "oneOf": [
-        { "type": "boolean", "description": "BREAK-GLASS ONLY (discouraged): when true, pods render WITHOUT runAsNonRoot/securityContext hardening. Sole remaining un-harden path after the enableVaultCA guard removal. Leave false/unset in normal operation.", "default": false },
+        { "type": "boolean", "description": "BREAK-GLASS ONLY (discouraged): when true, EVERY pod in the release renders WITHOUT runAsNonRoot/securityContext hardening — release-wide, cannot be scoped per-application. The only flag that removes the securityContext hardening block (applications.<name>.enableDebugMode's privileged sidecar is a separate un-hardened-container route). Kyverno require-run-as-non-root backstop is Enforce only on development; production-csp/data run Audit. Not settable via mc-environment environments[]. Leave false/unset; any use must be temporary.", "default": false },
         { "type": "null" }
       ]
     },

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -92,6 +92,12 @@
         { "type": "null" }
       ]
     },
+    "disableSecurity": {
+      "oneOf": [
+        { "type": "boolean", "description": "BREAK-GLASS ONLY (discouraged): when true, pods render WITHOUT runAsNonRoot/securityContext hardening. Sole remaining un-harden path after the enableVaultCA guard removal. Leave false/unset in normal operation.", "default": false },
+        { "type": "null" }
+      ]
+    },
     "manualOtelConfig": {
       "oneOf": [
         { "type": "boolean", "description": "Take over OpenTelemetry configuration from the chart. When true the chart injects no OTEL_* env vars, no auto-instrumentation annotations and no otel-log volume, and overrides disableOtelAutoinstrumentation", "default": false },

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -68,11 +68,17 @@ environment:
 ## Platform-wide settings
 
 ## @param enableVaultCA Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code)
+## @param disableSecurity BREAK-GLASS ONLY (discouraged): when true, pods render without runAsNonRoot/securityContext hardening
 ## @param manualOtelConfig Take over OpenTelemetry configuration from the chart (default false = chart-managed)
 ## @param disableOtelAutoinstrumentation Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)
 ## @param tolerations [array] Default tolerations for all applications
 ## @param deployment Deployment folder name (should match the subfolder containing the specific deployment)
 enableVaultCA: false
+
+## BREAK-GLASS ONLY — leave false. When true, pods ship WITHOUT runAsNonRoot/securityContext
+## hardening (both pod- and container-level). This is the sole remaining un-harden path since
+## the enableVaultCA guard removal; setting it is discouraged and should be temporary.
+disableSecurity: false
 
 ## The two OTel keys below have DELIBERATELY OPPOSITE defaults. They are not interchangeable and do
 ## not track each other:

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -68,16 +68,23 @@ environment:
 ## Platform-wide settings
 
 ## @param enableVaultCA Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code)
-## @param disableSecurity BREAK-GLASS ONLY (discouraged): when true, pods render without runAsNonRoot/securityContext hardening
+## @param disableSecurity BREAK-GLASS ONLY (discouraged): when true, every pod in the release renders without runAsNonRoot/securityContext hardening
 ## @param manualOtelConfig Take over OpenTelemetry configuration from the chart (default false = chart-managed)
 ## @param disableOtelAutoinstrumentation Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)
 ## @param tolerations [array] Default tolerations for all applications
 ## @param deployment Deployment folder name (should match the subfolder containing the specific deployment)
 enableVaultCA: false
 
-## BREAK-GLASS ONLY — leave false. When true, pods ship WITHOUT runAsNonRoot/securityContext
-## hardening (both pod- and container-level). This is the sole remaining un-harden path since
-## the enableVaultCA guard removal; setting it is discouraged and should be temporary.
+## BREAK-GLASS ONLY — leave false. When true, EVERY pod in the release (all workloads) ships
+## WITHOUT runAsNonRoot/securityContext hardening; this cannot be scoped per-application.
+## Admission backstop: Kyverno require-run-as-non-root is Enforce ONLY on development —
+## production-csp/data run Audit, so setting this there removes the chart's non-root guarantee
+## with report-only admission and no backstop (containers run as whatever the image USER
+## specifies). This is the only flag that removes the hardening block (though not the only
+## route to an un-hardened container — see applications.<name>.enableDebugMode's privileged
+## sidecar); setting it is discouraged and must be temporary.
+## Not settable through mc-environment `environments[]` (its schema rejects the key and
+## appset.yaml does not forward it) — only directly-managed mycarrier-helm value files. Intentional.
 disableSecurity: false
 
 ## The two OTel keys below have DELIBERATELY OPPOSITE defaults. They are not interchangeable and do


### PR DESCRIPTION
## Context
DEVOPS-176 follow-up (bd mycarrier-c463.31). After the `enableVaultCA` guard removal in `_podsecurity.tpl` (bd homc), `disableSecurity` is the SOLE flag that ships pods without `runAsNonRoot`/securityContext hardening. It was undocumented and absent from `values.schema.json`.

## Change
Doc + schema ONLY, zero behavior change.

- `values.schema.json`: property added following the `enableVaultCA` sibling pattern (`oneOf` boolean/null, default `false`, break-glass description) — no `additionalProperties`/`required` changes, so it cannot reject existing valid consumer values.
- `values.yaml`: key `disableSecurity: false` with break-glass comment.
- `README.md`: Platform Settings table row.

## Verification
- `helm lint`: PASS
- Default-values render: byte-identical before vs after
- `--set disableSecurity=true`: renders with hardening absent (expected break-glass behavior, unchanged)
- `--set-string disableSecurity=yes`: now FAILS schema validation ("got string, want boolean")
- `helm unittest`: 638/638 pass

## Notes
- The top-level schema has no `additionalProperties: false`, so a typo'd key name still passes silently — pre-existing, intentionally NOT tightened in this change (tightening it could reject existing consumer values).
- Chart.yaml version bump intentionally omitted — CI (`chart-version-bumper` via `.github/workflows/main.yml`) bumps + publishes on PR merge. Chart PUBLISH/propagation to consumers is a SEPARATE step from this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)