### PR TITLE
chore(mycarrier-helm): remove dead lifecycle postStart code

### DIFF
--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1398,7 +1398,7 @@ When contributing to this chart, please follow the coding standards defined in t
 
 | Name                             | Description                                                                            | Value        |
 | -------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
-| `enableVaultCA`                  | Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code) | `false`      |
+| `enableVaultCA`                  | Enable Vault CA certificate download during pod startup (no-op: its postStart hook was removed in DEVOPS-176; flag retained for values compatibility) | `false`      |
 | `disableSecurity`                | BREAK-GLASS ONLY (discouraged). When true, every pod in the release renders without runAsNonRoot/securityContext hardening — release-wide, cannot be scoped per-application. Only flag that removes the hardening block (`enableDebugMode`'s privileged sidecar is a separate route). Kyverno `require-run-as-non-root` is Enforce only on development (Audit on production-csp/data). Not settable through mc-environment `environments[]` — direct mycarrier-helm values only. | `false`      |
 | `manualOtelConfig`               | Take over OpenTelemetry configuration from the chart (default false = chart-managed)   | `false`      |
 | `disableOtelAutoinstrumentation` | Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)      | `true`       |

--- a/charts/mycarrier-helm/templates/_lifecycle.tpl
+++ b/charts/mycarrier-helm/templates/_lifecycle.tpl
@@ -4,12 +4,6 @@
 {{- end }}
 {{- end -}}
 
-{{- define "helm.defaultLifecyclePostStart" -}}
-{{- if .Values.enableVaultCA }}
-{{- printf "curl -k https://vault.infra:8200/v1/pki/ca/pem --output /usr/local/share/ca-certificates/vault.crt;update-ca-certificates" }}
-{{- end }}
-{{- end -}}
-
 {{- define "helm.defaultLifecyclePreStop" -}}
 {{- $language := include "helm.getLanguage" . -}}
 {{- if $language }}
@@ -28,20 +22,3 @@
 {{- printf "pkill vault-env || true" }}
 {{- end }}
 {{- end -}}
-
-# {{- define "helm.lifecycle" -}}
-# {{- $customPostStart := include "helm.defaultLifecyclePostStart" . }}
-# {{- $defaultPreStop := include "helm.defaultLifecyclePreStop" . }}
-# {{- $customPreStopDelay := include "helm.defaultPreStopDelay" . }}
-# {{/* Use dig to safely access nested properties from application context */}}
-# {{- $postStartCommand := dig "lifecycle" "postStart" "echo postStartTest" .application }}
-# {{- $preStopCommand := dig "lifecycle" "preStop" $defaultPreStop .application }}
-#
-# lifecycle:
-#   postStart:
-#     exec:
-#       command: [ "/bin/sh", "-c", {{ printf "%s; %s" $postStartCommand $customPostStart | trim | quote }} ]
-#   preStop:
-#     exec:
-#       command: [ "/bin/sh", "-c", {{ printf "%s%s" $customPreStopDelay $preStopCommand | trim | quote }} ]
-# {{- end -}}

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -20,11 +20,11 @@ context only ever carries one of .application/.cronjob/.job.
 {{- end -}}
 
 {{/*
-enableVaultCA no longer gates hardening here: its only other consumer,
-helm.defaultLifecyclePostStart's root-requiring vault.crt postStart hook, is
-dead code (helm.lifecycle, its sole caller, is fully commented out in
-_lifecycle.tpl). Kyverno require-run-as-non-root is Enforce on dev, so
-disableSecurity remains the sole explicit break-glass opt-out.
+enableVaultCA does not gate hardening here: it has no template consumer at
+all — its last one, helm.defaultLifecyclePostStart's root-requiring
+vault.crt postStart hook, was removed as dead code (DEVOPS-176). Kyverno
+require-run-as-non-root is Enforce on dev, so disableSecurity remains the
+sole explicit break-glass opt-out.
 */}}
 {{- define "helm.podSecurityContext" -}}
 {{- if not .Values.disableSecurity }}
@@ -44,11 +44,11 @@ securityContext:
 {{- end -}}
 
 {{/*
-enableVaultCA no longer gates hardening here: its only other consumer,
-helm.defaultLifecyclePostStart's root-requiring vault.crt postStart hook, is
-dead code (helm.lifecycle, its sole caller, is fully commented out in
-_lifecycle.tpl). Kyverno require-run-as-non-root is Enforce on dev, so
-disableSecurity remains the sole explicit break-glass opt-out.
+enableVaultCA does not gate hardening here: it has no template consumer at
+all — its last one, helm.defaultLifecyclePostStart's root-requiring
+vault.crt postStart hook, was removed as dead code (DEVOPS-176). Kyverno
+require-run-as-non-root is Enforce on dev, so disableSecurity remains the
+sole explicit break-glass opt-out.
 */}}
 {{- define "helm.containerSecurityContext" -}}
 {{- if not .Values.disableSecurity }}

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -254,7 +254,7 @@ tests:
             runAsGroup: 3000
             runAsNonRoot: true
 
-  - it: should still harden pod and container securityContext when enableVaultCA is true (enableVaultCA no longer gates hardening; its only other consumer is dead code)
+  - it: should still harden pod and container securityContext when enableVaultCA is true (enableVaultCA has no consumer; it does not gate hardening)
     set:
       environment.name: "dev"
       enableVaultCA: true

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -67,7 +67,7 @@ environment:
 ## @section Platform Settings
 ## Platform-wide settings
 
-## @param enableVaultCA Enable Vault CA certificate download during pod startup (no longer affects securityContext hardening; that postStart hook is currently dead code)
+## @param enableVaultCA Enable Vault CA certificate download during pod startup (no-op: its postStart hook was removed in DEVOPS-176; flag retained for values compatibility)
 ## @param disableSecurity BREAK-GLASS ONLY (discouraged): when true, every pod in the release renders without runAsNonRoot/securityContext hardening
 ## @param manualOtelConfig Take over OpenTelemetry configuration from the chart (default false = chart-managed)
 ## @param disableOtelAutoinstrumentation Disable OpenTelemetry Operator auto-instrumentation only (set to false to enable)


### PR DESCRIPTION
## Summary

Removes dead code from `charts/mycarrier-helm/templates/_lifecycle.tpl` (bd `mycarrier-c463.32`, DEVOPS-176 follow-up to #115):

- **`helm.defaultLifecyclePostStart`** (former lines 7–11) — the `enableVaultCA`-gated `vault.crt` / `update-ca-certificates` postStart hook. Unreachable: its only reference sat inside `helm.lifecycle`, which nothing invoked.
- **`helm.lifecycle`** (former lines 32–47) — every line prefixed `# `. Since `#` is not a comment token in Go text/template, this was actually a *registered* define that nothing called (uncalled, not uncallable) — credit to review for the correction. Either way it contributed nothing to rendered output.

Zero rendered-manifest change, proven by the byte-identical render diff below.

Second commit (review feedback): rewords the prose that described this code as "dead code, fully commented out in `_lifecycle.tpl`" — which would have become a *false*, checkable claim once the code no longer exists. Updated: both `_podsecurity.tpl` hardening-rationale comments, the test title at `tests/security_context_test.yaml:257`, and the `enableVaultCA` description in `values.yaml` + its `README.md` row. Comment/prose text only — no template logic touched.

## Verification

- Chart-wide grep for `helm.lifecycle`, `defaultLifecyclePostStart`, `enableVaultCA`, `vault.crt`, `update-ca-certificates`: **no live consumer**. Remaining `enableVaultCA` references (values.yaml default, mc-environment forwarding, tests) are inert — tests explicitly assert the flag has no effect.
- `helm template` default values, this branch vs a fresh `main` worktree: **byte-identical** (SHA256 match). This is the load-bearing proof — no unittest renders `_lifecycle.tpl`, so test counts alone are coverage-neutral for this change.
- `helm lint charts/mycarrier-helm`: **PASS** (1 chart linted, 0 failed)
- `helm unittest`: mycarrier-helm **638/638 passed** (59 suites, 6/6 snapshots); mc-environment **12/12 passed**

## Notes / out of scope

- `helm.defaultPreStopDelay` and `helm.defaultLifecyclePreStop` remain in place, though now also caller-less within this file — outside dispatched scope; candidate follow-up.
- `enableVaultCA` itself is now consumer-less; removing the flag would touch the values schema and mc-environment forwarding — design/compat decision, candidate follow-up.
- README regeneration via `readme-generator-for-helm` reformats the whole parameter table and pulls in unrelated description drift, so the `enableVaultCA` row was hand-edited to match `values.yaml`; a full regen belongs in its own PR.
- Chart.yaml version bump is bot-automated in this repo ("Automated Change" commits); no manual bump made. Chart publish is a separate step.

**Do not merge without tower approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
