### PR TITLE
feat(mycarrier-helm): fail-closed addCapabilities allow-list guard

### DIFF
--- a/charts/mycarrier-helm/README.md
+++ b/charts/mycarrier-helm/README.md
@@ -1257,7 +1257,8 @@ preserves the chart's existing default rendering — nothing changes until you s
 | Key | Default | Notes |
 | --- | --- | --- |
 | `readOnlyRootFilesystem` | `false` | Sets the container's `readOnlyRootFilesystem`. |
-| `addCapabilities` | `[]` | Applications only. All capabilities are dropped by default (`drop: [ALL]`); list specific capabilities here to add them back. |
+| `addCapabilities` | `[]` | Applications only. All capabilities are dropped by default (`drop: [ALL]`); list specific capabilities here to add them back. Each entry MUST also appear in `allowedCapabilities` (see below) or the render `fail`s. |
+| `allowedCapabilities` | `[]` | Applications only. Chart-security allow-list gating `addCapabilities`. **Empty by default** — no capability is permitted until explicitly allow-listed here (with security sign-off). A capability in `addCapabilities` not present in `allowedCapabilities` fails the render with a clear error message naming the capability and the currently-allowed set. |
 | `fsGroup` | unset | Sets the pod-level `fsGroup`. Must be `>= 1` — `0` is the root group and is rejected by the values schema. **This lower bound is ORG POLICY**, enforced by `MyCarrier-DevOps/kyverno-policies` `require-non-root-groups` (rule `check-fsGroup`: "must be empty or greater than zero") — it is **not** an upstream Pod Security Standards control. The [PSS spec](https://kubernetes.io/docs/concepts/security/pod-security-standards/) contains zero occurrences of `fsGroup`/`runAsGroup`/`supplementalGroups`; those were PodSecurityPolicy fields, and PSP is retired. |
 | `seccompProfile` | unset | Sets the pod-level `seccompProfile`, e.g. `{type: RuntimeDefault}`. |
 

--- a/charts/mycarrier-helm/templates/_podsecurity.tpl
+++ b/charts/mycarrier-helm/templates/_podsecurity.tpl
@@ -64,7 +64,14 @@ securityContext:
     drop:
       - ALL
 {{- if .application }}
-{{- with (dig "securityContext" "addCapabilities" (list) .application) }}
+{{- $addCaps := dig "securityContext" "addCapabilities" (list) .application }}
+{{- with $addCaps }}
+{{- $allowedCaps := dig "securityContext" "allowedCapabilities" (list) $.application }}
+{{- range . }}
+{{- if not (has . $allowedCaps) }}
+{{- fail (printf "Capability %q is not permitted by the chart security policy. To permit it, add it to application.securityContext.allowedCapabilities (with security sign-off). Currently allowed: %v." . $allowedCaps) }}
+{{- end }}
+{{- end }}
     add:
 {{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/mycarrier-helm/tests/security_context_test.yaml
+++ b/charts/mycarrier-helm/tests/security_context_test.yaml
@@ -100,7 +100,7 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].securityContext.capabilities.add
 
-  - it: should add back a single capability via securityContext.addCapabilities
+  - it: should add back a single capability via securityContext.addCapabilities when allow-listed
     set:
       environment.name: "dev"
       applications.single-add-cap-app:
@@ -112,6 +112,8 @@ tests:
           tag: "1.0.0"
         securityContext:
           addCapabilities:
+            - NET_BIND_SERVICE
+          allowedCapabilities:
             - NET_BIND_SERVICE
     asserts:
       - isKind:
@@ -125,7 +127,7 @@ tests:
           value:
             - NET_BIND_SERVICE
 
-  - it: should add back multiple capabilities via securityContext.addCapabilities
+  - it: should add back multiple capabilities via securityContext.addCapabilities when allow-listed
     set:
       environment.name: "dev"
       applications.multi-add-cap-app:
@@ -137,6 +139,9 @@ tests:
           tag: "1.0.0"
         securityContext:
           addCapabilities:
+            - NET_BIND_SERVICE
+            - SYS_TIME
+          allowedCapabilities:
             - NET_BIND_SERVICE
             - SYS_TIME
     asserts:
@@ -151,6 +156,62 @@ tests:
           value:
             - NET_BIND_SERVICE
             - SYS_TIME
+
+  - it: should fail the render when addCapabilities is set without a matching allowedCapabilities entry (empty allow-list by default)
+    set:
+      environment.name: "dev"
+      applications.unallowed-add-cap-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "unallowed-add-cap-app"
+          tag: "1.0.0"
+        securityContext:
+          addCapabilities:
+            - NET_BIND_SERVICE
+    asserts:
+      - failedTemplate:
+          errorMessage: 'Capability "NET_BIND_SERVICE" is not permitted by the chart security policy. To permit it, add it to application.securityContext.allowedCapabilities (with security sign-off). Currently allowed: [].'
+
+  - it: should fail the render for a capability not covered by a non-empty allowedCapabilities list
+    set:
+      environment.name: "dev"
+      applications.disallowed-add-cap-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "disallowed-add-cap-app"
+          tag: "1.0.0"
+        securityContext:
+          addCapabilities:
+            - SYS_ADMIN
+          allowedCapabilities:
+            - NET_BIND_SERVICE
+    asserts:
+      - failedTemplate:
+          errorMessage: 'Capability "SYS_ADMIN" is not permitted by the chart security policy. To permit it, add it to application.securityContext.allowedCapabilities (with security sign-off). Currently allowed: [NET_BIND_SERVICE].'
+
+  - it: should not fail and should render no add block when addCapabilities is unset (allow-list guard is inert)
+    set:
+      environment.name: "dev"
+      applications.no-addcaps-app:
+        enabled: true
+        deploymentType: deployment
+        image:
+          registry: "test-registry"
+          repository: "no-addcaps-app"
+          tag: "1.0.0"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
 
   - it: should honor application-level securityContext fsGroup and seccompProfile on the pod spec
     set:

--- a/charts/mycarrier-helm/values.schema.json
+++ b/charts/mycarrier-helm/values.schema.json
@@ -2441,10 +2441,18 @@
         },
         "addCapabilities": {
           "type": "array",
-          "description": "Linux capabilities to add back on top of the drop-all default. All capabilities are dropped by default; list ones here to add them back. Only honoured on the application (Deployment) path by _podsecurity.tpl — jobs and cronjobs do not read this field.",
+          "description": "Linux capabilities to add back on top of the drop-all default. All capabilities are dropped by default; list ones here to add them back. Only honoured on the application (Deployment) path by _podsecurity.tpl — jobs and cronjobs do not read this field. Each entry MUST also appear in allowedCapabilities or the render fails (fail-closed, empty allow-list by default).",
           "items": {
             "type": "string"
           }
+        },
+        "allowedCapabilities": {
+          "type": "array",
+          "description": "Chart-security allow-list gating addCapabilities. Empty by default — a capability in addCapabilities that is not also listed here fails the render with a clear error. Only add a capability here with security sign-off. Only honoured on the application (Deployment) path by _podsecurity.tpl.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
         }
       }
     }

--- a/charts/mycarrier-helm/values.yaml
+++ b/charts/mycarrier-helm/values.yaml
@@ -245,8 +245,13 @@ applications: {}
 #   securityContext:
 #     readOnlyRootFilesystem: false
 #     # All capabilities are dropped by default (drop: [ALL]). List specific
-#     # capabilities here to add them back for this application only:
+#     # capabilities here to add them back for this application only. Each
+#     # capability listed here MUST also be listed in allowedCapabilities
+#     # below, or the render fails with a clear error (empty allow-list by
+#     # default - no capability is permitted until explicitly allow-listed):
 #     # addCapabilities:
+#     #   - NET_BIND_SERVICE
+#     # allowedCapabilities:
 #     #   - NET_BIND_SERVICE
 #
 #   # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Context
bd `mycarrier-c463.35` part 2 (part 1 was a capability survey — see `standup-notes/2026/08/c463.35-part2-capsurvey.md`). Today `_podsecurity.tpl`'s `addCapabilities` block renders any Linux capability declared under `.application.securityContext.addCapabilities` unconditionally — there is no gate.

## Design (empty default allow-list, fail-closed)
- New values key `.application.securityContext.allowedCapabilities` (list, default `[]`).
- Render-time guard in `charts/mycarrier-helm/templates/_podsecurity.tpl` (the addCapabilities block): for each capability in `addCapabilities`, if it is **not** in `allowedCapabilities`, `fail` with:
  > `Capability "<CAP>" is not permitted by the chart security policy. To permit it, add it to application.securityContext.allowedCapabilities (with security sign-off). Currently allowed: [<list>].`
- `addCapabilities` empty/unset → no-op, renders as today.
- A capability present in both lists → renders as today.
- No default allow-list — a capability is permitted only if the consuming values file explicitly opts in.

## Consumer coupling — result: NONE required
Per the survey, KrakenD was flagged as "the one real consumer" of `addCapabilities` via `NET_BIND_SERVICE`. Verified directly: **KrakenD's rendered manifests (`DevOps/AppCluster-Infrastructure/Config/krakend/deployment.yaml`, `DevOps/KrakenD/deployment.yaml`) are `# Source: krakend/templates/deployment.yaml` — output of a separate `krakend` chart (v0.1.28) with its own hardcoded `securityContext.capabilities.add`.** It does not go through `mycarrier-helm`'s `_podsecurity.tpl` or the `.application.securityContext.addCapabilities` key at all. Same for `charts/hyperdx` (separate `hdx-oss-v2` chart, own `capabilities.add` field).

A repo-wide grep for `addCapabilities` across the whole `mycarrier` working tree found **zero** real (non-test) consumers of this chart's key — only this chart's own `tests/security_context_test.yaml` fixtures used it, and those have been updated in this PR to add `allowedCapabilities` so they keep passing. **No coordinated change is required in any other repo before this chart version is consumed.**

## Schema
`values.schema.json`'s `workloadSecurityContext` definition has `additionalProperties: false`, so `allowedCapabilities` was also added there (alongside `addCapabilities`) — otherwise the new key would be rejected by schema validation.

## Tests added (`charts/mycarrier-helm/tests/security_context_test.yaml`)
- `addCapabilities:[NET_BIND_SERVICE]` without `allowedCapabilities` → render **fails** with the exact guard message (empty allow-list).
- `addCapabilities:[NET_BIND_SERVICE]` with matching `allowedCapabilities` → renders the capability (existing tests updated to add the allow-list).
- `addCapabilities:[SYS_ADMIN]` with a non-empty but non-matching `allowedCapabilities:[NET_BIND_SERVICE]` → **fails**.
- `addCapabilities` unset → no `add` block, no failure (guard is inert).

## Gates
- `helm lint charts/mycarrier-helm`: **PASS** (1 chart linted, 0 failed).
- `helm unittest charts/mycarrier-helm`: **641/641 passed** (59 suites, 6/6 snapshots) — includes the 4 new/updated guard tests.
- `helm template` with default values (no `addCapabilities`), before vs after: **byte-identical** (MD5 match).

## Chart.yaml
No manual version bump — per repo convention (see #115/#116), `chart-version-bumper` CI bumps + publishes automatically on merge to `main`. Publish/propagation to consumers is a separate step from this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)